### PR TITLE
Add flag to specify where to look for hooks.

### DIFF
--- a/man/mkinitcpio.8.txt
+++ b/man/mkinitcpio.8.txt
@@ -36,10 +36,13 @@ Options
 	Set 'directory' as the location where the initramfs is built. This might be
 	useful to generate a shutdown ramfs in '/run/initramfs'.
 
+*-D, \--hookdir* 'directory'::
+	Set 'directory' as the location where hooks will be searched for when 
+	generating the image.
+
 *-g, \--generate* 'filename'::
 	Generate a CPIO image as 'filename'. Default: no; this means nothing will be
 	written to the filesystem unless this option is specified.
-
 
 *-H, \--hookhelp* 'hookname'::
 	Output help for hookname 'hookname'.

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -56,6 +56,7 @@ usage: ${0##*/} [options]
    -s, --save                   Save build directory. (default: no)
    -d, --generatedir <dir>      Write generated image into <dir>
    -t, --builddir <dir>         Use DIR as the temporary build directory
+   -D, --hookdir <dir>          Specify where to look for hooks.
    -V, --version                Display version information and exit
    -v, --verbose                Verbose output (default: no)
    -z, --compress <program>     Use an alternate compressor on the image
@@ -404,6 +405,11 @@ while :; do
         -r|--moduleroot)
             shift
             _optmoduleroot=$1
+            ;;
+        -D|--hookdir)
+            shift
+            _d_hooks="$(readlink -f "$1")/hooks"
+            _d_install="$(readlink -f "$1")/install"
             ;;
         --)
             shift

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -14,8 +14,7 @@ _f_functions=functions
 _f_config=mkinitcpio.conf
 _d_hooks="$PWD/hooks:/usr/lib/initcpio/hooks:/lib/initcpio/hooks"
 _d_install="$PWD/install:/usr/lib/initcpio/install:/lib/initcpio/install"
-_d_flag_hooks=""
-_d_flag_install=""
+_d_flag_{hooks,install}=
 _d_firmware=({/usr,}/lib/firmware/updates {/usr,}/lib/firmware)
 _d_presets=mkinitcpio.d
 
@@ -426,8 +425,8 @@ if [[ -t 1 ]] && (( _optcolor )); then
 fi
 
 if [[ -n $_d_flag_hooks && -n $_d_flag_install ]]; then
-    _d_hooks=$_d_flag_hooks
-    _d_install=$_d_flag_install
+    _d_hooks=${_d_flag_hooks%:}
+    _d_install=${_d_flag_install%:}
 fi
 
 # insist that /proc and /dev be mounted (important for chroots)

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -14,6 +14,8 @@ _f_functions=functions
 _f_config=mkinitcpio.conf
 _d_hooks="$PWD/hooks:/usr/lib/initcpio/hooks:/lib/initcpio/hooks"
 _d_install="$PWD/install:/usr/lib/initcpio/install:/lib/initcpio/install"
+_d_flag_hooks=""
+_d_flag_install=""
 _d_firmware=({/usr,}/lib/firmware/updates {/usr,}/lib/firmware)
 _d_presets=mkinitcpio.d
 
@@ -408,8 +410,8 @@ while :; do
             ;;
         -D|--hookdir)
             shift
-            _d_hooks="$(readlink -f "$1")/hooks"
-            _d_install="$(readlink -f "$1")/install"
+            _d_flag_hooks+="$1/hooks:"
+            _d_flag_install+="$1/install:"
             ;;
         --)
             shift
@@ -421,6 +423,11 @@ done
 
 if [[ -t 1 ]] && (( _optcolor )); then
     try_enable_color
+fi
+
+if [[ -n $_d_flag_hooks && -n $_d_flag_install ]]; then
+    _d_hooks=$_d_flag_hooks
+    _d_install=$_d_flag_install
 fi
 
 # insist that /proc and /dev be mounted (important for chroots)


### PR DESCRIPTION
I'm aware that `mkinitcpio` does use `$PWD/{install,hook}`,  but it feels a bit silly that we are still looking through a path if we only want to be looking through a specific location.

The motivation for this is to look into creating a test suite for `mkinitcpio`. Specifying a hook directory for any additional hooks feels apt.