### PR TITLE
Fix hookdir flag

### DIFF
--- a/mkinitcpio
+++ b/mkinitcpio
@@ -14,7 +14,8 @@ _f_functions=functions
 _f_config=mkinitcpio.conf
 _d_hooks="$PWD/hooks:/usr/lib/initcpio/hooks:/lib/initcpio/hooks"
 _d_install="$PWD/install:/usr/lib/initcpio/install:/lib/initcpio/install"
-_d_flag_{hooks,install}=
+_d_flag_hooks=
+_d_flag_install=
 _d_firmware=({/usr,}/lib/firmware/updates {/usr,}/lib/firmware)
 _d_presets=mkinitcpio.d
 
@@ -316,8 +317,8 @@ process_preset() (
 trap 'cleanup 130' INT
 trap 'cleanup 143' TERM
 
-_opt_short='A:c:g:H:hk:nLMPp:r:S:sd:t:Vvz:'
-_opt_long=('add:' 'addhooks:' 'config:' 'generate:' 'hookhelp:' 'help'
+_opt_short='A:c:D:g:H:hk:nLMPp:r:S:sd:t:Vvz:'
+_opt_long=('add:' 'addhooks:' 'config:' 'generate:' 'hookdir': 'hookhelp:' 'help'
           'kernel:' 'listhooks' 'automods' 'moduleroot:' 'nocolor' 'allpresets'
           'preset:' 'skiphooks:' 'save' 'generatedir:' 'builddir:' 'version' 'verbose' 'compress:')
 

--- a/shell/bash-completion
+++ b/shell/bash-completion
@@ -56,7 +56,7 @@ _files_from_dirs() {
 
 _mkinitcpio() {
     local action cur prev opts
-    opts=(-A --addhooks -c --config -g --generate -H --hookhelp -h --help -k --kernel
+    opts=(-A --addhooks -c --config -D --hookdir -g --generate -H --hookhelp -h --help -k --kernel
           -L --listhooks -M --automods -n --nocolor -P --allpresets -p --preset -r --moduleroot
           -S --skiphooks -s --save -t --builddir -V --version -v --verbose -z --compress)
 
@@ -65,7 +65,7 @@ _mkinitcpio() {
     case $prev in
         -[cg]|--config|--generate)
             _filedir ;;
-        -r|--moduleroot|-t|--builddir)
+        -D|--hookdir|-r|--moduleroot|-t|--builddir)
             _filedir -d ;;
         -k|--kernel)
             _find_kernel_versions ;;

--- a/shell/zsh-completion
+++ b/shell/zsh-completion
@@ -39,6 +39,7 @@ case $service in
         _arguments : \
             '(-A --addhooks)'{-A,--addhooks}'[Add specified hooks, comma separated, to image]::usr hooks:_path_files -W /usr/lib/initcpio/install::lib hooks:_path_files -W /lib/initcpio/install' \
             '(-c --config)'{-c,--config}'[Use alternate config file. (default: /etc/mkinitcpio.conf)]:config files:_files' \
+            '(-D --hookdir)'{-D,--hookdir}'[Specify where to look for hooks.]:directories:_files -/' \
             '(-g --generate)'{-g,--generate}'[Generate cpio image and write to specified path]:config files:_files' \
             '(-H --hookhelp)'{-H,--hookhelp}'[Display help for given hook and exit]::usr hooks:_path_files -W /usr/lib/initcpio/install::lib hooks:_path_files -W /lib/initcpio/install' \
             '(-h --help)'{-h,--help}'[Display this message and exit]' \


### PR DESCRIPTION
The hookdir option was still lacking addition to the option parser. As well, as the shell completions were lacking it.