### PR TITLE
Make build process and resulting images capable of storing secrets.

### DIFF
--- a/functions
+++ b/functions
@@ -659,7 +659,7 @@ initialize_buildroot() {
 
     local workdir= kernver=$1 arch=$(uname -m) buildroot
 
-    if ! workdir=$(mktemp -d --tmpdir mkinitcpio.XXXXXX); then
+    if ! workdir=$(umask 077 && mktemp -d --tmpdir mkinitcpio.XXXXXX); then
         error 'Failed to create temporary working directory in %s' "${TMPDIR:-/tmp}"
         return 1
     fi

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -223,10 +223,11 @@ build_image() {
             sort -z |
             LANG=C bsdtar --null -cnf - -T - |
             LANG=C bsdtar --uid 0 --gid 0 --null -cf - --format=newc @- |
-            $compress "${COMPRESSION_OPTIONS[@]}" > "$out"
+            $compress "${COMPRESSION_OPTIONS[@]}" |
+            (rm -f "$out" && umask 077 && cat > "$out")
 
     pipestatus=("${PIPESTATUS[@]}")
-    pipeprogs=('find' 'sort' 'bsdtar (step 1)' 'bsdtar (step 2)' "$compress")
+    pipeprogs=('find' 'sort' 'bsdtar (step 1)' 'bsdtar (step 2)' "$compress" 'save image')
 
     popd >/dev/null
 


### PR DESCRIPTION
When storing secrets (eg: crypttab keyfiles) in initramfs, ensure the secrets are protected during the build process, and in the resulting initramfs images.  This works best when initramfs is also stored on an encrypted or otherwise secured filesystem.  Access by root is not a problem since "dmsetup table --showkeys" will show the keys to root anyway.