### PR TITLE
[functions] Ignore modinfo built-in modules

### DIFF
--- a/functions
+++ b/functions
@@ -371,7 +371,7 @@ add_module() {
     target=${1%.ko*} target=${target//-/_}
 
     # skip expensive stuff if this module has already been added
-    (( _addedmodules["$target"] == 1 )) && return
+    (( _addedmodules["$target"] > 0 )) && return
 
     while IFS=':= ' read -r -d '' field value; do
         case "$field" in


### PR DESCRIPTION
modinfo have started reporting filenames as "(builtin)" on built-in
modules. Ignore these and continue with other modules.

Fixes: https://bugs.archlinux.org/task/65564
Introduced in: https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/commit/?id=e7e2cb61fa9f1db3429d91ef6accff549500d268

Signed-off-by: Morten Linderud <morten@linderud.pw>