### PR TITLE
Remove hexdump usage

### DIFF
--- a/functions
+++ b/functions
@@ -144,7 +144,9 @@ kver() {
     # to the version string by reading 2 bytes out of image at at
     # address 0x20E. this leads us to a string of, at most, 128 bytes.
     # read the first word from this string as the kernel version.
-    local offset=$(hexdump -s 526 -n 2 -e '"%0d"' "$1")
+    local offset=$(dd if="$1" bs=1 count=2 skip=526 2>/dev/null)
+    printf -v offset '%02x' "'${offset:1:1}" "'${offset:0:1}"
+    printf -v offset '%d' "0x$offset"
     [[ $offset = +([0-9]) ]] || return 1
 
     read kver _ < \

--- a/lsinitcpio
+++ b/lsinitcpio
@@ -77,71 +77,51 @@ size_to_human() {
 detect_filetype() {
     local bytes
 
-    read -rd '' bytes < <(hexdump -n 6 -e '"%c"' "$1")
+    read -rd '' -n 6 bytes < "$1"
+    printf -v bytes '%02x' "'${bytes:0:1}" "'${bytes:1:1}" "'${bytes:2:1}" \
+                           "'${bytes:3:1}" "'${bytes:4:1}" "'${bytes:5:1}"
     case $bytes in
-        '070701')
+        303730373031)
             # no compression
             echo
-            return
             ;;
-        $'\xfd7zXZ')
+        fd377a585a00)
             echo 'xz'
-            return
             ;;
-    esac
-
-    read -rd '' bytes < <(hexdump -n 4 -e '"%c"' "$1")
-    if [[ $bytes = $'\x89LZO' ]]; then
-        echo 'lzop'
-        return
-    fi
-
-    read -rd '' bytes < <(hexdump -n 2 -e '"%x"' "$1")
-    if [[ $bytes = '8b1f' ]]; then
-        echo 'gzip'
-        return
-    fi
-
-    read -rd '' bytes < <(hexdump -n 4 -e '"%x"' "$1")
-    case $bytes in
-        184d2204)
+        894c5a4f*)
+            echo 'lzop'
+            ;;
+        8b1f*)
+            echo 'gzip'
+            ;;
+        184d2204*)
             error 'Newer lz4 stream format detected! This may not boot!'
             echo 'lz4'
-            return
             ;;
-        184c2102)
+        184c2102*)
             echo 'lz4 -l'
-            return
             ;;
-        fd2fb528)
+        fd2fb528*)
             echo 'zstd'
-            return
             ;;
+        425a68*)
+            echo 'bzip2'
+            ;;
+        5d*)
+            # lzma detection sucks and there's really no good way to
+            # do it without reading large portions of the stream. this
+            # check is good enough for GNU tar, apparently, so it's good
+            # enough for me.
+            echo 'lzma'
+            ;;
+        *)
+            # still nothing? hrmm, maybe the user goofed and it's a kernel
+            if kver "$1" >/dev/null; then
+                die '%s is a kernel image, not an initramfs image!' "$1"
+            fi
+            # out of ideas, we're done here.
+            die 'Unexpected file type. Are you sure %s is an initramfs?' "$1"
     esac
-
-    read -rd '' bytes < <(hexdump -n 3 -e '"%c"' "$1")
-    if [[ $bytes == 'BZh' ]]; then
-        echo 'bzip2'
-        return
-    fi
-
-    # lzma detection sucks and there's really no good way to
-    # do it without reading large portions of the stream. this
-    # check is good enough for GNU tar, apparently, so it's good
-    # enough for me.
-    read -rd '' bytes < <(hexdump -n 3 -e '"%x"' "$1")
-    if [[ $bytes = '5d' ]]; then
-        echo 'lzma'
-        return
-    fi
-
-    # still nothing? hrmm, maybe the user goofed and it's a kernel
-    if kver "$1" >/dev/null; then
-        die '%s is a kernel image, not an initramfs image!' "$1"
-    fi
-
-    # out of ideas, we're done here.
-    die 'Unexpected file type. Are you sure %s is an initramfs?' "$1"
 }
 
 analyze_image() {

--- a/shell/bash-completion
+++ b/shell/bash-completion
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 _detect_kver() {
-    local kver_validator='^[[:digit:]]+(\.[[:digit:]]+)+'
-    offset=$(hexdump -s 526 -n 2 -e '"%0d"' "$1" 2>/dev/null) || return 1
+    local kver_validator='^[[:digit:]]+(\.[[:digit:]]+)+' offset
+    offset=$(dd if="$1" bs=1 count=2 skip=526 2>/dev/null) || return 1
+    printf -v offset '%02x' "'${offset:1:1}" "'${offset:0:1}"
+    printf -v offset '%d' "0x$offset"
     read kver _ < \
         <(dd if="$1" bs=1 count=127 skip=$(( offset + 0x200 )) 2>/dev/null)
     [[ $kver =~ $kver_validator ]] && printf "$kver"

--- a/shell/zsh-completion
+++ b/shell/zsh-completion
@@ -1,8 +1,10 @@
 #compdef lsinitcpio mkinitcpio
 
 _detect_kver() {
-    local __ kver_validator='^[[:digit:]]+(\.[[:digit:]]+)+'
-    offset=$(hexdump -s 526 -n 2 -e '"%0d"' "$1" 2>/dev/null) || return 1
+    local __ kver_validator='^[[:digit:]]+(\.[[:digit:]]+)+' offset
+    offset=$(dd if="$1" bs=1 count=2 skip=526 2>/dev/null) || return 1
+    printf -v offset '%02x' "'${offset:1:1}" "'${offset:0:1}"
+    printf -v offset '%d' "0x$offset"
     read kver __ < \
         <(dd if="$1" bs=1 count=127 skip=$(( offset + 0x200 )) 2>/dev/null)
     [[ $kver =~ $kver_validator ]] && printf "$kver"


### PR DESCRIPTION
lsinitcpio: Use read to get the first 6 bytes, convert them to hex, and
compare them to the hex versions of the magic bytes of each compression
format
Replace the kernel version offset determination using hexdump with dd to
skip bytes, and printf to convert the bytes to decimal