### PR TITLE
do not uncompress and re-depmod kernel modules

### DIFF
--- a/functions
+++ b/functions
@@ -769,8 +769,7 @@ try_enable_color() {
 }
 
 install_modules() {
-    local m moduledest=$BUILDROOT/lib/modules/$KERNELVERSION
-    local -a xz_comp gz_comp
+    local m
 
     [[ $KERNELVERSION == none ]] && return 0
 
@@ -779,36 +778,12 @@ install_modules() {
         return 0
     fi
 
-    cp "$@" "$moduledest/kernel"
-
-    # unzip modules prior to recompression
-    for m in "$@"; do
-        case $m in
-            *.xz)
-                xz_comp+=("$moduledest/kernel/${m##*/}")
-                ;;
-            *.gz)
-                gz_comp+=("$moduledest/kernel/${m##*/}")
-                ;;
-        esac
+    for m; do
+        install -Dm644 "$m" "$BUILDROOT/$m"
     done
-    (( ${#xz_comp[*]} )) && xz -d "${xz_comp[@]}"
-    (( ${#gz_comp[*]} )) && gzip -d "${gz_comp[@]}"
 
-    msg "Generating module dependencies"
-    install -m644 -t "$moduledest" "$_d_kmoduledir"/modules.builtin
-
-    # we install all modules into kernel/, making the .order file incorrect for
-    # the module tree. munge it, so that we have an accurate index. This avoids
-    # some rare and subtle issues with module loading choices when an alias
-    # resolves to multiple modules, only one of which can claim a device.
-    awk -F'/' '{ print "kernel/" $NF }' \
-        "$_d_kmoduledir"/modules.order >"$moduledest/modules.order"
-
-    depmod -b "$BUILDROOT" "$KERNELVERSION"
-
-    # remove all non-binary module.* files (except devname for on-demand module loading)
-    rm "$moduledest"/modules.!(*.bin|devname|softdep)
+    install -Dm644 -t "$BUILDROOT/lib/modules/$KERNELVERSION" \
+        "$_d_kmoduledir"/modules{*.bin,.devname,.softdep}
 }
 
 # vim: set ft=sh ts=4 sw=4 et:


### PR DESCRIPTION
Installing kernel modules as-is without uncompressing reduces time spent
generating the image significantly at the cost of a small size increase.