### PR TITLE
block: only include drivers/mmc

### DIFF
--- a/install/block
+++ b/install/block
@@ -19,7 +19,7 @@ build() {
     add_checked_modules '/drivers/firewire/'
 
     # mmc
-    add_checked_modules '/(mmc|tifm_)'
+    add_checked_modules '/(drivers/mmc|tifm_)'
 
     # virtio
     add_checked_modules 'virtio'


### PR DESCRIPTION
Filtering only by mmc pulls in media/mmc which would include modules and
firmware for dvb.