### PR TITLE
resolve symlinks for all binaries

### DIFF
--- a/functions
+++ b/functions
@@ -578,7 +578,7 @@ add_binary() {
     #   $2: destination on initcpio (optional, defaults to same as source)
 
     local -a sodeps
-    local line= regex= binary= dest= mode= sodep= resolved=
+    local line= regex= binary= dest= mode= sodep= resolved= link=
 
     if [[ ${1:0:1} != '/' ]]; then
         binary=$(type -P "$1")
@@ -589,6 +589,19 @@ add_binary() {
     if [[ ! -f $binary ]]; then
         error "file not found: \`%s'" "$1"
         return 1
+    fi
+
+    # ldd fails to resolve libraries for binaries which depend on
+    # rpath/runpath $ORIGIN because it uses the symlink and not what
+    # it points to as the origin.
+    if ! link="$(readlink -f "$binary")"; then
+        return 1
+    fi
+    if [[ $binary != $link ]]; then
+        if ! add_symlink "$binary" "$link"; then
+            return 1
+        fi
+        binary=$link
     fi
 
     dest=${2:-$binary}


### PR DESCRIPTION
If a binary depends on libraries from rpath/runpath $ORIGIN and the
binary is a symlink, ldd fails to resolve dependencies because it uses
the symlink as origin.

```sh
$ ldd /usr/bin/java
	linux-vdso.so.1 (0x00007fff18d6c000)
	libjli.so => not found
	libc.so.6 => /usr/lib/libc.so.6 (0x00007fc8bd867000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007fc8bda61000)
$ ldd $(realpath /usr/bin/java)
	linux-vdso.so.1 (0x00007fff6fff3000)
	libjli.so => /usr/lib/jvm/java-8-openjdk/jre/bin/../lib/amd64/jli/libjli.so (0x00007fbf42591000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007fbf4239e000)
	libz.so.1 => /usr/lib/libz.so.1 (0x00007fbf42384000)
	libdl.so.2 => /usr/lib/libdl.so.2 (0x00007fbf4237e000)
	libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007fbf4235c000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007fbf425a9000)
```