### PR TITLE
resolve symlinks when checking for deprecation

### DIFF
--- a/functions
+++ b/functions
@@ -718,7 +718,7 @@ run_build_hook() {
     fi
 
     # check for deprecation
-    if resolved=$(readlink "$script") && [[ ${script##*/} != "${resolved##*/}" ]]; then
+    if resolved=$(readlink -f "$script") && [[ ${script##*/} != "${resolved##*/}" ]]; then
         warning "Hook '%s' is deprecated. Replace it with '%s' in your config" \
             "${script##*/}" "${resolved##*/}"
         script=$resolved


### PR DESCRIPTION
If a deprecation symlink points to a hook that collides with something
in PATH, it gets sourced instead. Use absolute paths when sourcing
install hooks.
```sh
$ readlink install/test
sleep
$ ./mkinitcpio -k none -c /dev/null -A test
==> Starting dry run: none
==> WARNING: Hook 'test' is deprecated. Replace it with 'sleep' in your config
functions: line 729: .: /usr/sbin/sleep: cannot execute binary file
==> ERROR: Failed to read sleep
==> Dry run complete, use -g IMAGE to generate a real image
```