### PR TITLE
Add fallback kernel version scraper

### DIFF
--- a/functions
+++ b/functions
@@ -133,6 +133,36 @@ parseopts() {
     return 0
 }
 
+kver_x86() {
+    # scrape the version out of the kernel image. locate the offset
+    # to the version string by reading 2 bytes out of image at at
+    # address 0x20E. this leads us to a string of, at most, 128 bytes.
+    # read the first word from this string as the kernel version.
+    local kver offset=$(hexdump -s 526 -n 2 -e '"%0d"' "$1")
+    [[ $offset = +([0-9]) ]] || return 1
+
+    read kver _ < \
+        <(dd if="$1" bs=1 count=127 skip=$(( offset + 0x200 )) 2>/dev/null)
+
+    printf '%s' "$kver"
+}
+
+kver_generic() {
+    # For unknown architectures, we can try to grep the uncompressed
+    # image for the boot banner.
+    # This should work at least for ARM when run on /boot/Image. On
+    # other architectures it may be worth trying rather than bailing,
+    # and inform the user if none was found.
+
+    # Loosely grep for `linux_banner`:
+    # https://elixir.bootlin.com/linux/v5.7.2/source/init/version.c#L46
+    local kver=
+
+    read _ _ kver _ < <(grep -m1 -aoE 'Linux version .(\.[-[:alnum:]]+)+' "$1")
+
+    printf '%s' "$kver"
+}
+
 kver() {
     # this is intentionally very loose. only ensure that we're
     # dealing with some sort of string that starts with something
@@ -140,15 +170,12 @@ kver() {
     # requirement for CONFIG_LOCALVERSION to be set.
     local kver re='^[[:digit:]]+(\.[[:digit:]]+)+'
 
-    # scrape the version out of the kernel image. locate the offset
-    # to the version string by reading 2 bytes out of image at at
-    # address 0x20E. this leads us to a string of, at most, 128 bytes.
-    # read the first word from this string as the kernel version.
-    local offset=$(hexdump -s 526 -n 2 -e '"%0d"' "$1")
-    [[ $offset = +([0-9]) ]] || return 1
-
-    read kver _ < \
-        <(dd if="$1" bs=1 count=127 skip=$(( offset + 0x200 )) 2>/dev/null)
+    local arch=$(uname -m)
+    if [[ $arch == @(i?86|x86_64) ]]; then
+        kver=$(kver_x86 "$1")
+    else
+        kver=$(kver_generic "$1")
+    fi
 
     [[ $kver =~ $re ]] || return 1
 

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -101,12 +101,6 @@ resolve_kernver() {
         return 0
     fi
 
-    arch=$(uname -m)
-    if [[ $arch != @(i?86|x86_64) ]]; then
-        error "kernel version extraction from image not supported for \`%s' architecture" "$arch"
-        return 1
-    fi
-
     if [[ ! -e $kernel ]]; then
         error "specified kernel image does not exist: \`%s'" "$kernel"
         return 1
@@ -115,6 +109,12 @@ resolve_kernver() {
     kver "$kernel" && return
 
     error "invalid kernel specified: \`%s'" "$1"
+
+    arch=$(uname -m)
+    if [[ $arch != @(i?86|x86_64) ]]; then
+        error "kernel version extraction from image not supported for \`%s' architecture" "$arch"
+        error "there's a chance the generic version extractor may work with a valid uncompressed kernel image"
+    fi
 
     return 1
 }


### PR DESCRIPTION
The kernel version scraper included in mkinitcpio works only on x86 kernel images.

This commit implements kernel version scraping on a generic architecture if an uncompressed image is provided.

With this commit I'm mainly targeting ALARM. However, since I wasn't able to find a static offset for the kernel version like on x86, I decided to go for a generic scraper that greps over the entire uncompressed image.

This is definitely inefficient, it takes ~300ms on my laptop with an NVMe SSD, 1.8s on my Rock64 with eMMC storage. However, it's better than nothing in my opinion, and people can still hardcode the kernel version in the preset just as before.