### PR TITLE
alpm-hooks should use Type = Path, not File

### DIFF
--- a/libalpm/hooks/60-mkinitcpio-remove.hook
+++ b/libalpm/hooks/60-mkinitcpio-remove.hook
@@ -1,5 +1,5 @@
 [Trigger]
-Type = File
+Type = Path
 Operation = Remove
 Target = usr/lib/modules/*/vmlinuz
 

--- a/libalpm/hooks/90-mkinitcpio-install.hook
+++ b/libalpm/hooks/90-mkinitcpio-install.hook
@@ -1,5 +1,5 @@
 [Trigger]
-Type = File
+Type = Path
 Operation = Install
 Operation = Upgrade
 Target = usr/lib/modules/*/vmlinuz


### PR DESCRIPTION
With reference to similar changes in other packages (systemd, kmod, dbus) it would be good to change here as well.

Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>