### PR TITLE
install/block: include NVDIMM modules

### DIFF
--- a/install/block
+++ b/install/block
@@ -23,6 +23,9 @@ build() {
 
     # virtio
     add_checked_modules 'virtio'
+
+    # nvdimm
+    add_checked_modules '/drivers/nvdimm/'
 }
 
 help() {


### PR DESCRIPTION
This allows for booting from an ISO that was copied to a pmem device, such as '/dev/pmem0'.
See also https://github.com/u-root/webboot/.

----

This is an alternative to #30.