### PR TITLE
fsck: do not complain about missing helper for tmpfs

### DIFF
--- a/install/fsck
+++ b/install/fsck
@@ -4,6 +4,8 @@ build() {
     local fsck= added=0
 
     add_fsck() {
+        [[ $1 = tmpfs ]] && return
+
         if [[ $1 = ext[234] ]]; then
             add_binary fsck.ext4
             add_symlink /usr/bin/fsck.ext2 fsck.ext4


### PR DESCRIPTION
Within a (build) chroot we may have root on tmpfs. There is no fsck
helper for tmpfs, so do not complain.

Signed-off-by: Christian Hesse <mail@eworm.de>