### PR TITLE
support zstd compression

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,6 +15,7 @@ optdepends=('xz: Use lzma or xz compression for the initramfs image'
             'bzip2: Use bzip2 compression for the initramfs image'
             'lzop: Use lzo compression for the initramfs image'
             'lz4: Use lz4 compression for the initramfs image'
+            'zstd: Use zstd compression for the initramfs image'
             'mkinitcpio-nfs-utils: Support for root filesystem on NFS')
 backup=(etc/mkinitcpio.conf)
 

--- a/lsinitcpio
+++ b/lsinitcpio
@@ -113,6 +113,10 @@ detect_filetype() {
             echo 'lz4 -l'
             return
             ;;
+        fd2fb528)
+            echo 'zstd'
+            return
+            ;;
     esac
 
     read -rd '' bytes < <(hexdump -n 3 -e '"%c"' "$1")

--- a/man/mkinitcpio.conf.5.txt
+++ b/man/mkinitcpio.conf.5.txt
@@ -54,9 +54,9 @@ Variables
 
 	Defines a program to filter the generated image through. As of linux 2.6.38,
 	the kernel understands the compression formats yielded by the *gzip*, *bzip2*,
-	*lz4*, *lzop*, *lzma*, and *xz* compressors. If unspecified, this setting
-	defaults to *gzip* compression. In order to create an uncompressed image, define
-	this variable as *cat*.
+	*lz4*, *lzop*, *lzma*, and *xz* compressors. Compression via *zstd* was added
+	in linux 5.9. If unspecified, this setting defaults to *gzip* compression.
+	In order to create an uncompressed image, define this variable as *cat*.
 +
 It's not hard to realize that a filter such as a *tac* or *rev* will cause
 *mkinitcpio* to report success but generate a useless image. Similarly, using a

--- a/mkinitcpio.conf
+++ b/mkinitcpio.conf
@@ -60,6 +60,7 @@ HOOKS=(base udev autodetect modconf block filesystems keyboard fsck)
 #COMPRESSION="xz"
 #COMPRESSION="lzop"
 #COMPRESSION="lz4"
+#COMPRESSION="zstd"
 
 # COMPRESSION_OPTIONS
 # Additional options for the compressor


### PR DESCRIPTION
Linux 5.9 supports zstd compressed initramfs, so add support here.