### PR TITLE
Fix setting uid=0 gid=0 in archive

### DIFF
--- a/mkinitcpio
+++ b/mkinitcpio
@@ -221,8 +221,8 @@ build_image() {
     # If this pipeline changes, |pipeprogs| below needs to be updated as well.
     find . -mindepth 1 -printf '%P\0' |
             sort -z |
-            LANG=C bsdtar --null -cnf - -T - |
-            LANG=C bsdtar --uid 0 --gid 0 --null -cf - --format=newc @- |
+            LANG=C bsdtar --uid 0 --gid 0 --null -cnf - -T - |
+            LANG=C bsdtar --null -cf - --format=newc @- |
             $compress "${COMPRESSION_OPTIONS[@]}" > "$out"
 
     pipestatus=("${PIPESTATUS[@]}")


### PR DESCRIPTION
Setting uid and gid in bsdtar (step 2) gave no effect, so it's moved to step 1. Now all uids and gids are setting to zero. So created archive is user-independent.
Step 2 just adds files from archive from stdin, but doesn't set any metadata to them.
Before that if you ran mkinitcpio as non-root user, uid and gid of each file from archive were set to your non-zero uid and non-zero gid.

**This bug caused a following problem:**
If you create initramfs with non-root user and try to boot with it, you will get
```
mount: /proc: must be superuser to use mount.
mount: /sys: must be superuser to use mount.
mount: /dev: must be superuser to use mount.
mount: /run: must be superuser to use mount.
```
because all files in your initrd environment have non-zero uid and gid.