### PR TITLE
Allow user to override default compression options

### DIFF
--- a/mkinitcpio
+++ b/mkinitcpio
@@ -206,13 +206,13 @@ build_image() {
             msg "Creating %s-compressed initcpio image: %s" "$compress" "$out"
             ;;&
         xz)
-            COMPRESSION_OPTIONS+=('--check=crc32')
+            COMPRESSION_OPTIONS=('--check=crc32' "${COMPRESSION_OPTIONS[@]}")
             ;;
         lz4)
-            COMPRESSION_OPTIONS+=('-l')
+            COMPRESSION_OPTIONS=('-l' "${COMPRESSION_OPTIONS[@]}")
             ;;
         zstd)
-            COMPRESSION_OPTIONS+=('-19' '-T0')
+            COMPRESSION_OPTIONS=('-19' '-T0' "${COMPRESSION_OPTIONS[@]}")
             ;;
     esac
 


### PR DESCRIPTION
Background info: I was using lz4 for its speed and switched to zstd after the recent release. However `zstd -19` is very slow on my machine and I wish to override the compression level which I found is impossible and hence this patch.

Another related question, why only zstd utilize a [compression level](https://github.com/archlinux/mkinitcpio/blob/master/mkinitcpio#L215) that is not the program default (`-3`)? All others (lz4, gzip) use the default compression level from the respective programs.
EDIT: Answering the question myself, see: https://github.com/archlinux/mkinitcpio/pull/35#discussion_r460510753