### PR TITLE
Strip modules of debug symbols on strip hook.

### DIFF
--- a/install/strip
+++ b/install/strip
@@ -15,6 +15,10 @@ build() {
                 # Binaries
                 strip --strip-all "$bin"
                 ;;
+            *application/x-object*)
+                # Kernel objects
+                strip --strip-debug "$bin"
+                ;;
         esac
     done
 }


### PR DESCRIPTION
In the same vein of the other options, we want to strip the kernel modules of their debug symbols when passing the strip hook.