### PR TITLE
mount handler fallback shell

### DIFF
--- a/init
+++ b/init
@@ -41,7 +41,7 @@ unset rootdev
 fsck_root
 
 # Mount root at /new_root
-"$mount_handler" /new_root
+"$mount_handler" /new_root || launch_interactive_shell --exec
 
 run_hookfunctions 'run_latehook' 'late hook' $LATEHOOKS
 run_hookfunctions 'run_cleanuphook' 'cleanup hook' $CLEANUPHOOKS


### PR DESCRIPTION
If mount handler crash, we just see kernel panic kill init message. 

I added fallback shell. now we can see error message.