### PR TITLE
mkinitcpio: Support kernel version detection on other archtectures

### DIFF
--- a/functions
+++ b/functions
@@ -139,6 +139,21 @@ kver() {
     # resembling dotted decimal notation. remember that there's no
     # requirement for CONFIG_LOCALVERSION to be set.
     local kver re='^[[:digit:]]+(\.[[:digit:]]+)+'
+    local arch=$(uname -m)
+
+    if [[ $arch != @(i?86|x86_64) ]]; then
+        # Use the generic way by searching the plaintext string
+        # "Linux version " and use the 3rd item as the kernel version
+        #
+        # This is much slower as we need to read the full uncompressed
+        # kernel to locate its kernel version string, thus this should
+        # be the last resort.
+        kver=$(strings "$1" | grep "Linux version " | cut -d\  -f 3)
+
+        [[ $kver =~ $re ]] || return 1
+        printf '%s' "$kver"
+        return
+    fi
 
     # scrape the version out of the kernel image. locate the offset
     # to the version string by reading 2 bytes out of image at at

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -101,12 +101,6 @@ resolve_kernver() {
         return 0
     fi
 
-    arch=$(uname -m)
-    if [[ $arch != @(i?86|x86_64) ]]; then
-        error "kernel version extraction from image not supported for \`%s' architecture" "$arch"
-        return 1
-    fi
-
     if [[ ! -e $kernel ]]; then
         error "specified kernel image does not exist: \`%s'" "$kernel"
         return 1


### PR DESCRIPTION
Current mkinitpcio only support kernel version detection on x86/x86_64.

This makes mkinitcpio on Archlinuxarm/ManajaroARM harder to generate their
initramfs, as they have to specify the kernel version, other than let
mkinitcpio to detect it automatically.

This limitation is especially obvious when kernel bisecting is involved,
as the kernel version can change between each bisect, and re-generating
initramfs with inconsistent kernel version is a blockage.

This patch adds a fallback method to detect kernel version for
uncompressed kernel image.
The fallback method will use "strings" command to filter out the
"Kernel version " string and use the next string as kernel version.

This works on arm64 and x86_64 uncompressed kernel pretty well, but it's
still slower since we need to read the full kernel image.

Thus the existing x86_64 magic offset way is still kept as is, and the
new generic method is only a fallback for arch without a magic offset.

Signed-off-by: Qu Wenruo <wqu@suse.com>