### PR TITLE
functions: canonicalize symbolic link path

### DIFF
--- a/functions
+++ b/functions
@@ -724,7 +724,7 @@ run_build_hook() {
     fi
 
     # check for deprecation
-    if resolved=$(readlink "$script") && [[ ${script##*/} != "${resolved##*/}" ]]; then
+    if resolved=$(readlink -e "$script") && [[ ${script##*/} != "${resolved##*/}" ]]; then
         warning "Hook '%s' is deprecated. Replace it with '%s' in your config" \
             "${script##*/}" "${resolved##*/}"
         script=$resolved


### PR DESCRIPTION
Deprectating a hook 'old-hook' and replacing it with new hook 'new-hook'
required the symlink to point to an absolute target:

/usr/lib/initcpio/install/old-hook -> /usr/lib/initcpio/install/new-hook

Let's canonicalize the path read by `readlink`, this allows to link
relative path in symbolic link:

/usr/lib/initcpio/install/old-hook -> new-hook