### PR TITLE
functions: read from symlink, do not update script path

### DIFF
--- a/functions
+++ b/functions
@@ -727,7 +727,6 @@ run_build_hook() {
     if resolved=$(readlink "$script") && [[ ${script##*/} != "${resolved##*/}" ]]; then
         warning "Hook '%s' is deprecated. Replace it with '%s' in your config" \
             "${script##*/}" "${resolved##*/}"
-        script=$resolved
     fi
 
     # source


### PR DESCRIPTION
Deprectating a hook 'old-hook' and replacing it with new hook 'new-hook'
required the symlink to point to an absolute target:

/usr/lib/initcpio/install/old-hook -> /usr/lib/initcpio/install/new-hook

Let's just print the warning, then read from symlink. This way we can not
break the path and a relative path works as well.

/usr/lib/initcpio/install/old-hook -> new-hook