### PR TITLE
Switch to zstd by default

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,13 +9,13 @@ groups=('base')
 conflicts=('mkinitcpio')
 provides=("mkinitcpio=$pkgver" "initramfs")
 depends=('mkinitcpio-busybox>=1.19.4-2' 'kmod' 'util-linux>=2.23' 'libarchive' 'coreutils'
-         'awk' 'bash' 'findutils' 'grep' 'filesystem>=2011.10-1' 'systemd' 'gzip')
+         'awk' 'bash' 'findutils' 'grep' 'filesystem>=2011.10-1' 'systemd' 'zstd')
 makedepends=('asciidoc' 'git' 'sed')
-optdepends=('xz: Use lzma or xz compression for the initramfs image'
+optdepends=('gzip: Use gzip compression for the initramfs image'
+            'xz: Use lzma or xz compression for the initramfs image'
             'bzip2: Use bzip2 compression for the initramfs image'
             'lzop: Use lzo compression for the initramfs image'
             'lz4: Use lz4 compression for the initramfs image'
-            'zstd: Use zstd compression for the initramfs image'
             'mkinitcpio-nfs-utils: Support for root filesystem on NFS')
 backup=(etc/mkinitcpio.conf)
 

--- a/man/mkinitcpio.conf.5.txt
+++ b/man/mkinitcpio.conf.5.txt
@@ -52,13 +52,11 @@ Variables
 
 *COMPRESSION*::
 
-	Defines a program to filter the generated image through. As of linux 2.6.38,
-	the kernel understands the compression formats yielded by the *gzip*, *bzip2*,
-	*lz4*, *lzop*, *lzma*, and *xz* compressors. As of linux 5.9 the kernel also
-	understands the compression formats yielded by the *zstd* compressor.
-	If unspecified, this setting defaults to *gzip* compression.
-	In order to create an uncompressed image, define
-	this variable as *cat*.
+	Defines a program to filter the generated image through. The kernel
+	understands the compression formats yielded by the *zstd*, *gzip*, *bzip2*,
+	*lz4*, *lzop*, *lzma*, and *xz* compressors. If unspecified, this setting
+	defaults to *zstd* compression. In order to create an uncompressed image,
+	define this variable as *cat*.
 +
 It's not hard to realize that a filter such as a *tac* or *rev* will cause
 *mkinitcpio* to report success but generate a useless image. Similarly, using a

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -508,7 +508,7 @@ if [[ $_optgenimg ]]; then
         die 'Unable to write to %s' "$_optgenimg"
     fi
 
-    _optcompress=${_optcompress:-${COMPRESSION:-gzip}}
+    _optcompress=${_optcompress:-${COMPRESSION:-zstd}}
     if ! type -P "$_optcompress" >/dev/null; then
         warning "Unable to locate compression method: %s" "$_optcompress"
         _optcompress=cat

--- a/mkinitcpio.conf
+++ b/mkinitcpio.conf
@@ -52,15 +52,15 @@ FILES=()
 HOOKS=(base udev autodetect modconf block filesystems keyboard fsck)
 
 # COMPRESSION
-# Use this to compress the initramfs image. By default, gzip compression
+# Use this to compress the initramfs image. By default, zstd compression
 # is used. Use 'cat' to create an uncompressed image.
+#COMPRESSION="zstd"
 #COMPRESSION="gzip"
 #COMPRESSION="bzip2"
 #COMPRESSION="lzma"
 #COMPRESSION="xz"
 #COMPRESSION="lzop"
 #COMPRESSION="lz4"
-#COMPRESSION="zstd"
 
 # COMPRESSION_OPTIONS
 # Additional options for the compressor


### PR DESCRIPTION
Since all the Arch kernels now support zstd, switch to it by default