### PR TITLE
functions: add nls_ascii to fat quirks

### DIFF
--- a/functions
+++ b/functions
@@ -419,8 +419,8 @@ add_module() {
     # handle module quirks
     case $target in
         fat)
-            add_module "nls_cp437?"
-            add_module "nls_iso8859-1?"
+            add_module "nls_ascii?" # from CONFIG_FAT_DEFAULT_IOCHARSET
+            add_module "nls_cp437?" # from CONFIG_FAT_DEFAULT_CODEPAGE
             ;;
         ocfs2)
             add_module "configfs?"


### PR DESCRIPTION
All Arch Linux's officially supported kernels changed from `CONFIG_FAT_DEFAULT_IOCHARSET="iso8859-1"` to `CONFIG_FAT_DEFAULT_IOCHARSET="ascii"`:

- https://github.com/archlinux/svntogit-packages/commit/34bfe7d720658c7f0d14c61f44fb2a5516073c12
- https://github.com/archlinux/svntogit-packages/commit/c75cb9e71b52eef4de9ed706f01ddf5a05f9f738
- https://github.com/archlinux/svntogit-packages/commit/283332609549a479357d2d58adf80d12e89e345f
- https://github.com/archlinux/svntogit-packages/commit/760c402675ad74417005b9abad5f997f677c801e

Although currently Arch kernels have `CONFIG_NLS_ASCII=y`, since it's a tristate option, it's better to add it just in case.

----

I'm not sure if `add_module "nls_iso8859-1?"` should be kept to support kernels built with `CONFIG_FAT_DEFAULT_IOCHARSET="iso8859-1"` or support for them is irrelevant and it can be removed.