### PR TITLE
[mkinitcpio] Create UEFI executables

### DIFF
--- a/man/mkinitcpio.8.txt
+++ b/man/mkinitcpio.8.txt
@@ -35,7 +35,7 @@ Options
 	or '/proc/cmdline'. Only used along with '--uefi'.
 
 *-c, \--config* 'config'::
-	Use 'config' file to generate the ramdisk. Default: '/etc/mkinitcpio.conf'
+	Use 'config' file to generate the ramdisk. Default: '/etc/mkinitcpio.conf'.
 
 *-d, \--generatedir* 'directory'::
 	Set 'directory' as the location where the initramfs is built. This might be
@@ -109,7 +109,7 @@ Options
 *-r, \--moduleroot* 'root'::
 	Specifies the root directory to find modules in, defaulting to '/'.
 
-*-R, \--osrelease* 'filename';;
+*-R, \--osrelease* 'filename'::
 	Include a os-release file for the UEFI executable. Only used if '--uefi' is
 	specified. Default: '/etc/os-release' or '/usr/lib/os-release'.
 
@@ -382,6 +382,15 @@ Examples
 *mkinitcpio -g /boot/initramfs-linux.img -k /boot/vmlinuz-linux*::
 	Create an initial ramdisk for the kernel at /boot/vmlinuz-linux. The
 	resulting image will be written to /boot/initramfs-linux.img.
+
+*mkinitcpio -g /boot/initramfs-linux.img -k /boot/vmlinuz-linux --uefi /efi/EFI/Linux/systemd-linux.efi*::
+	Create an initial ramdisk for the kernel along with a UEFI executable.
+	The resuling executable will be written to /efi/EFI/Linux/systemd-linux.efi.
+
+*mkinitcpio -g /boot/initramfs-linux.img -k /boot/vmlinuz-linux -U /efi/EFI/Linux/systemd-linux.efi -M /boot/intel-ucode.img -l /usr/share/systemd/bootctl/splash-arch.bmp*::
+	Create an initial ramdisk for the kernel and an UEFI executable. This
+	also includes the Intel CPU microcode and a splash image which will be
+	used during boot.
 
 See also
 --------

--- a/man/mkinitcpio.8.txt
+++ b/man/mkinitcpio.8.txt
@@ -29,11 +29,6 @@ Options
 	after all other hooks from the config file. Multiple hooks should be
 	comma-separated. This option can be specified multiple times.
 
-*-C, \--cmdline* 'config'::
-	Use kernel cmdline with UEFI executable. If none is specified it will
-	try find one of the files '/etc/kernel/cmdline', '/usr/share/kernel/cmdline'
-	or '/proc/cmdline'. Only used along with '--uefi'.
-
 *-c, \--config* 'config'::
 	Use 'config' file to generate the ramdisk. Default: '/etc/mkinitcpio.conf'.
 
@@ -64,28 +59,10 @@ Options
 *-L, \--listhooks*::
 	List all available hooks.
 
-*-l, \--splash* 'filename'::
-	UEFI executables can show a bitmap file on boot.
-
-*-I, \--uefistub* 'filename'::
-	UEFI stub image used for UEFI executable generation. Only used if '--uefi'
-	is specified. Default: Attempts to look for a systemd-boot or gummiboot
-	stub loader.
-
-*-i, \--kernelimage* 'filename'::
-	Include a kernel image for the UEFI executable. This is only used if
-	'--uefi' is specified.  Default: one of
-	'/lib/modules/$KERNELVERSION/vmlinuz', '/boot/vmlinuz-$KERNELVERSION', or
-	'/boot/vmlinuz-linux'.
-
 *-M, \--automods*::
 	Display modules found via autodetection. mkinitcpio will automatically try to
 	determine which kernel modules are needed to start your computer. This option
 	lists which modules were detected.
-
-*-m, \--microcode* 'filename'::
-	Include microcode into the UEFI executable. This option is only used if
-	'--uefi' is specified. Default: no.
 
 *-n, \--nocolor*::
 	Disable color output.
@@ -96,6 +73,7 @@ Options
 	booting. This combines the initramfs, the kernel, any specified microcode
 	and the kernel cmdline into one executable. This is useful for boot chain
 	integrity where the file is signed. Default: no.
+	For a list of relevant options see 'Options for UEFi executable' below.
 
 *-P, \--allpresets*::
 	Process all presets contained in '/etc/mkinitcpio.d'. See the '-p' option for
@@ -108,10 +86,6 @@ Options
 
 *-r, \--moduleroot* 'root'::
 	Specifies the root directory to find modules in, defaulting to '/'.
-
-*-R, \--osrelease* 'filename'::
-	Include a os-release file for the UEFI executable. Only used if '--uefi' is
-	specified. Default: '/etc/os-release' or '/usr/lib/os-release'.
 
 *-S, \--skiphooks* 'hooks'::
 	Skip 'hooks' when generating the image. Multiple hooks should be comma-separated.
@@ -136,6 +110,34 @@ Options
 
 *-z, \--compress* 'compress'::
 	Override the compression method with the 'compress' program.
+
+Options for UEFi executable
+---------------------------
+
+*--cmdline* 'config'::
+	Use kernel cmdline with UEFI executable. If none is specified it will
+	try find one of the files '/etc/kernel/cmdline', '/usr/share/kernel/cmdline'
+	or '/proc/cmdline'.
+
+*--splash* 'filename'::
+	UEFI executables can show a bitmap file on boot.
+
+*--uefistub* 'filename'::
+	UEFI stub image used for UEFI executable generation.
+	Default: Attempts to look for a systemd-boot or gummiboot
+	stub loader.
+
+*--kernelimage* 'filename'::
+	Include a kernel image for the UEFI executable. Default: one of
+	'/lib/modules/$KERNELVERSION/vmlinuz', '/boot/vmlinuz-$KERNELVERSION', or
+	'/boot/vmlinuz-linux'.
+
+*--microcode* 'filename'::
+	Include microcode into the UEFI executable. Default: no.
+
+*--osrelease* 'filename'::
+	Include a os-release file for the UEFI executable.
+	Default: '/etc/os-release' or '/usr/lib/os-release'.
 
 About Presets
 -------------
@@ -383,11 +385,11 @@ Examples
 	Create an initial ramdisk for the kernel at /boot/vmlinuz-linux. The
 	resulting image will be written to /boot/initramfs-linux.img.
 
-*mkinitcpio -g /boot/initramfs-linux.img -k /boot/vmlinuz-linux --uefi /efi/EFI/Linux/systemd-linux.efi*::
+*mkinitcpio -U /efi/EFI/Linux/systemd-linux.efi*::
 	Create an initial ramdisk for the kernel along with a UEFI executable.
 	The resuling executable will be written to /efi/EFI/Linux/systemd-linux.efi.
 
-*mkinitcpio -g /boot/initramfs-linux.img -k /boot/vmlinuz-linux -U /efi/EFI/Linux/systemd-linux.efi -M /boot/intel-ucode.img -l /usr/share/systemd/bootctl/splash-arch.bmp*::
+*mkinitcpio -U /efi/EFI/Linux/systemd-linux.efi --microcode /boot/intel-ucode.img --splash /usr/share/systemd/bootctl/splash-arch.bmp*::
 	Create an initial ramdisk for the kernel and an UEFI executable. This
 	also includes the Intel CPU microcode and a splash image which will be
 	used during boot.

--- a/man/mkinitcpio.8.txt
+++ b/man/mkinitcpio.8.txt
@@ -32,7 +32,7 @@ Options
 *-C, \--cmdline* 'config'::
 	Use kernel cmdline with UEFI executable. If none is specified it will
 	try find one of the files '/etc/kernel/cmdline', '/usr/share/kernel/cmdline'
-	or `/proc/cmdline`. Only used along with '--uefi'.
+	or '/proc/cmdline'. Only used along with '--uefi'.
 
 *-c, \--config* 'config'::
 	Use 'config' file to generate the ramdisk. Default: '/etc/mkinitcpio.conf'

--- a/man/mkinitcpio.8.txt
+++ b/man/mkinitcpio.8.txt
@@ -29,8 +29,13 @@ Options
 	after all other hooks from the config file. Multiple hooks should be
 	comma-separated. This option can be specified multiple times.
 
+*-C, \--cmdline* 'config'::
+	Use kernel cmdline with UEFI executable. If none is specified it will
+	try find one of the files '/etc/kernel/cmdline', '/usr/share/kernel/cmdline'
+	or `/proc/cmdline`. Only used along with '--uefi'.
+
 *-c, \--config* 'config'::
-	Use 'config' file to generate the ramdisk. Default: /etc/mkinitcpio.conf
+	Use 'config' file to generate the ramdisk. Default: '/etc/mkinitcpio.conf'
 
 *-d, \--generatedir* 'directory'::
 	Set 'directory' as the location where the initramfs is built. This might be
@@ -59,13 +64,38 @@ Options
 *-L, \--listhooks*::
 	List all available hooks.
 
+*-l, \--splash* 'filename'::
+	UEFI executables can show a bitmap file on boot.
+
+*-I, \--uefistub* 'filename'::
+	UEFI stub image used for UEFI executable generation. Only used if '--uefi'
+	is specified. Default: Attempts to look for a systemd-boot or gummiboot
+	stub loader.
+
+*-i, \--kernelimage* 'filename'::
+	Include a kernel image for the UEFI executable. This is only used if
+	'--uefi' is specified.  Default: one of
+	'/lib/modules/$KERNELVERSION/vmlinuz', '/boot/vmlinuz-$KERNELVERSION', or
+	'/boot/vmlinuz-linux'.
+
 *-M, \--automods*::
 	Display modules found via autodetection. mkinitcpio will automatically try to
 	determine which kernel modules are needed to start your computer. This option
 	lists which modules were detected.
 
+*-m, \--microcode* 'filename'::
+	Include microcode into the UEFI executable. This option is only used if
+	'--uefi' is specified. Default: no.
+
 *-n, \--nocolor*::
 	Disable color output.
+
+*-U, \--uefi* 'filename'::
+	Generate a UEFI executable as 'filename'. If a CPIO image is successfully
+	built, it will be used to generate a UEFI executable stub image for UEFI
+	booting. This combines the initramfs, the kernel, any specified microcode
+	and the kernel cmdline into one executable. This is useful for boot chain
+	integrity where the file is signed. Default: no.
 
 *-P, \--allpresets*::
 	Process all presets contained in '/etc/mkinitcpio.d'. See the '-p' option for
@@ -78,6 +108,10 @@ Options
 
 *-r, \--moduleroot* 'root'::
 	Specifies the root directory to find modules in, defaulting to '/'.
+
+*-R, \--osrelease* 'filename';;
+	Include a os-release file for the UEFI executable. Only used if '--uefi' is
+	specified. Default: '/etc/os-release' or '/usr/lib/os-release'.
 
 *-S, \--skiphooks* 'hooks'::
 	Skip 'hooks' when generating the image. Multiple hooks should be comma-separated.

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -453,7 +453,7 @@ preload_builtin_modules() {
 trap 'cleanup 130' INT
 trap 'cleanup 143' TERM
 
-_opt_short='A:C:c:D:g:H:hk:I:i:nLl:Mm:Pp:R:r:S:sd:t:U:Vvz:'
+_opt_short='A:c:D:g:H:hk:nLMPp:r:S:sd:t:U:Vvz:'
 _opt_long=('add:' 'addhooks:' 'config:' 'generate:' 'hookdir': 'hookhelp:' 'help'
           'kernel:' 'listhooks' 'automods' 'moduleroot:' 'nocolor' 'allpresets'
           'preset:' 'skiphooks:' 'save' 'generatedir:' 'builddir:' 'version' 'verbose' 'compress:'

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -61,8 +61,8 @@ usage: ${0##*/} [options]
    -s, --save                   Save build directory. (default: no)
    -d, --generatedir <dir>      Write generated image into <dir>
    -t, --builddir <dir>         Use DIR as the temporary build directory
-   -D, --hookdir <dir>          Specify where to look for hooks.
-   -U, --uefi <path>            Build EFI image
+   -D, --hookdir <dir>          Specify where to look for hooks
+   -U, --uefi <path>            Build an UEFI executable
    -m, --microcode <path>       Location of microcode for UEFI executable
    -R, --osrelease <path>       Include os-release (default: /usr/lib/os-release)
    -l, --splash <path>          Include bitmap splash for UEFI executable
@@ -501,7 +501,7 @@ while :; do
         -U|--uefi)
             shift
             [[ -d $1 ]] && die "Invalid image path -- must not be a directory"
-            if ! _optuefi=$(readlink -f "$1") || [[ ! -e ${_optgenimg%/*} ]]; then
+            if ! _optuefi=$(readlink -f "$1") || [[ ! -e ${_optuefi%/*} ]]; then
                 die "Unable to write to path: \`%s'" "$1"
             fi
             ;;

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -333,7 +333,7 @@ build_uefi(){
     fi
     objcopy \
         --add-section .osrel="$osrelease" --change-section-vma .osrel=0x20000 \
-        --add-section .cmdline="$cmdline" --change-section-vma .cmdline=0x30000 \
+        --add-section .cmdline=<(grep '^[^#]' "$cmdline" | tr -s '\n' ' ') --change-section-vma .cmdline=0x30000 \
         --add-section .linux="$kernelimg" --change-section-vma .linux=0x2000000 \
         --add-section .initrd=<(cat ${microcode[@]} "$initramfs") --change-section-vma .initrd=0x3000000 \
         ${OBJCOPYARGS[@]} "$uefistub" "$out"

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -46,7 +46,6 @@ usage: ${0##*/} [options]
   Options:
    -A, --addhooks <hooks>       Add specified hooks, comma separated, to image
    -c, --config <config>        Use alternate config file. (default: /etc/mkinitcpio.conf)
-   -C, --cmdline <cmdline>      Set kernel line. (default content: /etc/kernel/cmdline, /proc/cmdline)
    -g, --generate <path>        Generate cpio image and write to specified path
    -H, --hookhelp <hookname>    Display help for given hook and exit
    -h, --help                   Display this message and exit
@@ -63,14 +62,17 @@ usage: ${0##*/} [options]
    -t, --builddir <dir>         Use DIR as the temporary build directory
    -D, --hookdir <dir>          Specify where to look for hooks
    -U, --uefi <path>            Build an UEFI executable
-   -m, --microcode <path>       Location of microcode for UEFI executable
-   -R, --osrelease <path>       Include os-release (default: /etc/os-release)
-   -l, --splash <path>          Include bitmap splash for UEFI executable
-   -i, --kernelimage <path>     Kernel image for UEFI executable
-   -I, --uefistub <path>        Location of UEFI stub loader
    -V, --version                Display version information and exit
    -v, --verbose                Verbose output (default: no)
    -z, --compress <program>     Use an alternate compressor on the image
+
+  Options for UEFI executable (-U, --uefi):
+   --cmdline <cmdline>          Set kernel line (default content: /etc/kernel/cmdline, /proc/cmdline)
+   --microcode <path>           Location of microcode
+   --osrelease <path>           Include os-release (default: /etc/os-release)
+   --splash <path>              Include bitmap splash
+   --kernelimage <path>         Kernel image
+   --uefistub <path>            Location of UEFI stub loader
 
 EOF
 }
@@ -474,7 +476,7 @@ while :; do
             shift
             _f_config=$1
             ;;
-        -C|--cmdline)
+        --cmdline)
             shift
             _optcmdline=$1
             ;;
@@ -536,23 +538,23 @@ while :; do
             hook_list
             exit 0
             ;;
-        -l|--splash)
+        --splash)
             shift
             [[ -f $1 ]] || die "Invalid file -- must be a file"
             _optsplash=$1
             ;;
-        -i|--kernelimage)
+        --kernelimage)
             shift
              _optkernelimage=$1
             ;;
-        -I|--uefistub)
+        --uefistub)
             shift
              _optkernelimage=$1
             ;;
         -M|--automods)
             _optshowautomods=1
             ;;
-        -m|--microcode)
+        --microcode)
             shift
             _optmicrocode+=($1)
             ;;
@@ -560,7 +562,7 @@ while :; do
             _optpreset=("$_d_presets"/*.preset)
             [[ -e ${_optpreset[0]} ]] || die "No presets found in $_d_presets"
             ;;
-        -R|--osrelease)
+        --osrelease)
             shift
             [[ ! -f $1 ]] && die "Invalid file -- must be a file"
             _optosrelease=$1

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -22,7 +22,7 @@ _d_presets=mkinitcpio.d
 # options and runtime data
 _optmoduleroot= _optgenimg=
 _optcompress= _opttargetdir=
-_optosrelease="/etc/os-release"
+_optosrelease=
 _optuefi= _optmicrocode=() _optcmdline= _optsplash= _optkernelimage= _optuefistub=
 _optshowautomods=0 _optsavetree=0 _optshowmods=0
 _optquiet=1 _optcolor=1
@@ -64,7 +64,7 @@ usage: ${0##*/} [options]
    -D, --hookdir <dir>          Specify where to look for hooks
    -U, --uefi <path>            Build an UEFI executable
    -m, --microcode <path>       Location of microcode for UEFI executable
-   -R, --osrelease <path>       Include os-release (default: /usr/lib/os-release)
+   -R, --osrelease <path>       Include os-release (default: /etc/os-release)
    -l, --splash <path>          Include bitmap splash for UEFI executable
    -i, --kernelimage <path>     Kernel image for UEFI executable
    -I, --uefistub <path>        Location of UEFI stub loader
@@ -307,6 +307,19 @@ build_uefi(){
     fi
     if [[ ! -f "$cmdline" ]]; then
         error "Kernel cmdline file '%s' not found" "$cmdline"
+        return 1
+    fi
+
+    if [[ -z "$osrelease" ]]; then
+        if [[ -f "/etc/os-release" ]]; then
+            osrelease="/etc/os-release"
+        elif [[ -f "/usr/lib/os-release" ]]; then
+            osrelease="/usr/lib/os-release"
+        fi
+        msg2 "Using os-release file %s" "$osrelease"
+    fi
+    if [[ ! -f "$osrelease" ]]; then
+        error "os-release file '%s' not found" "$osrelease"
         return 1
     fi
 

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -22,6 +22,8 @@ _d_presets=mkinitcpio.d
 # options and runtime data
 _optmoduleroot= _optgenimg=
 _optcompress= _opttargetdir=
+_optosrelease="/usr/lib/os-release"
+_optuefi= _optmicrocode= _optcmdline= _optsplash= _optkernelimage= _optuefistub=
 _optshowautomods=0 _optsavetree=0 _optshowmods=0
 _optquiet=1 _optcolor=1
 _optskiphooks=() _optaddhooks=() _hooks=()  _optpreset=()
@@ -44,6 +46,7 @@ usage: ${0##*/} [options]
   Options:
    -A, --addhooks <hooks>       Add specified hooks, comma separated, to image
    -c, --config <config>        Use alternate config file. (default: /etc/mkinitcpio.conf)
+   -C, --cmdline <cmdline>      Set kernel line. (default content: /etc/kernel/cmdline, /proc/cmdline)
    -g, --generate <path>        Generate cpio image and write to specified path
    -H, --hookhelp <hookname>    Display help for given hook and exit
    -h, --help                   Display this message and exit
@@ -59,6 +62,12 @@ usage: ${0##*/} [options]
    -d, --generatedir <dir>      Write generated image into <dir>
    -t, --builddir <dir>         Use DIR as the temporary build directory
    -D, --hookdir <dir>          Specify where to look for hooks.
+   -U, --uefi <path>            Build EFI image
+   -m, --microcode <path>       Location of microcode for UEFI executable
+   -R, --osrelease <path>       Include os-release (default: /usr/lib/os-release)
+   -l, --splash <path>          Include bitmap splash for UEFI executable
+   -i, --kernelimage <path>     Kernel image for UEFI executable
+   -I, --uefistub <path>        Location of UEFI stub loader
    -V, --version                Display version information and exit
    -v, --verbose                Verbose output (default: no)
    -z, --compress <program>     Use an alternate compressor on the image
@@ -251,6 +260,56 @@ build_image() {
     fi
 }
 
+build_uefi(){
+    set -x
+    local out=$1 microcode=$2 initramfs=$3 cmdline=$4 osrelease=$5 splash=$6 kernelimg=$7 uefistub=$8 errmsg=
+    OBJCOPYARGS=()
+
+    if [[ -z "$uefistub" ]]; then
+        for stub in {/usr,}/lib/systemd/boot/efi/linux{x64,ia32}.efi.stub {/usr,}/lib/gummiboot/linux{x64,ia32}.efi.stub; do
+            if [[ -f "$stub" ]]; then
+                uefistub="$stub"
+                break
+            fi
+        done
+    fi
+
+    if [[ -z "$kernelimg" ]]; then
+        for img in "/lib/modules/$KERNELIMAGE" "/boot/vmlinuz-$KERNELIMAGE" "/boot/vmlinuz-linuz"; do
+            if [[ -f "$img" ]]; then
+                KERNELIMAGE="$img"
+                break
+            fi
+        done
+    fi
+
+    if [[ -z "$cmdline" ]]; then
+        if [[ -f "/etc/kernel/cmdline" ]]; then
+            cmdline="/etc/kernel/cmdline"
+        else
+            cmdline="/proc/cmdline"
+        fi
+    fi
+
+    if [[ -n "$splash" ]]; then
+        OBJCOPYARGS+=("--add-section .splash=$splash --change-section-vma .splash=0x40000")
+    fi
+    msg "Creating EFI image: %s" "$out"
+    objcopy \
+        --add-section .osrel="$osrelease" --change-section-vma .osrel=0x20000 \
+        --add-section .cmdline="$cmdline" --change-section-vma .cmdline=0x30000 \
+        --add-section .linux="$kernelimg" --change-section-vma .linux=0x2000000 \
+        --add-section .initrd=<(cat "$microcode" "$initramfs" ) --change-section-vma .initrd=0x3000000 \
+        ${OBJCOPYARGS[@]} "$uefistub" "$out"
+
+    status=$?
+    if (( $status )) ; then
+        error "EFI image generation FAILED"
+    else
+        msg "EFI image generation successful"
+    fi
+}
+
 process_preset() (
     local preset=$1 preset_image= preset_options=
     local -a preset_mkopts preset_cmd
@@ -307,6 +366,16 @@ process_preset() (
             preset_cmd+=(${!preset_options}) # intentional word splitting
         fi
 
+        preset_efi_image=${p}_efi_image
+        if [[ ${!preset_efi_image:-$ALL_efi_image} ]]; then
+            preset_cmd+=(-U "${!preset_efi_image:-$ALL_efi_image}")
+        fi
+
+        preset_microcode=${p}_microcode
+        if [[ ${!preset_microcode:-$ALL_microcode} ]]; then
+            preset_cmd+=(-m "${!preset_microcode:-$ALL_microcode}")
+        fi
+
         msg2 "${preset_cmd[*]}"
         MKINITCPIO_PROCESS_PRESET=1 "$0" "${preset_cmd[@]}"
         (( $? )) && ret=1
@@ -345,10 +414,11 @@ preload_builtin_modules() {
 trap 'cleanup 130' INT
 trap 'cleanup 143' TERM
 
-_opt_short='A:c:D:g:H:hk:nLMPp:r:S:sd:t:Vvz:'
+_opt_short='A:c:D:g:H:hk:I:i:nLl:Mm:Pp:r:S:sd:t:U:Vvz:'
 _opt_long=('add:' 'addhooks:' 'config:' 'generate:' 'hookdir': 'hookhelp:' 'help'
           'kernel:' 'listhooks' 'automods' 'moduleroot:' 'nocolor' 'allpresets'
-          'preset:' 'skiphooks:' 'save' 'generatedir:' 'builddir:' 'version' 'verbose' 'compress:')
+          'preset:' 'skiphooks:' 'save' 'generatedir:' 'builddir:' 'version' 'verbose' 'compress:'
+          'uefi:' 'microcode:' 'splash:' 'kernelimage:' 'uefistub:')
 
 parseopts "$_opt_short" "${_opt_long[@]}" -- "$@" || exit 1
 set -- "${OPTRET[@]}"
@@ -366,6 +436,10 @@ while :; do
         -c|--config)
             shift
             _f_config=$1
+            ;;
+        -C|--cmdline)
+            shift
+            _optcmdline=$1
             ;;
         -k|--kernel)
             shift
@@ -400,6 +474,13 @@ while :; do
         -n|--nocolor)
             _optcolor=0
             ;;
+        -U|--uefi)
+            shift
+            [[ -d $1 ]] && die "Invalid image path -- must not be a directory"
+            if ! _optuefi=$(readlink -f "$1") || [[ ! -e ${_optgenimg%/*} ]]; then
+                die "Unable to write to path: \`%s'" "$1"
+            fi
+            ;;
         -v|--verbose)
             _optquiet=0
             ;;
@@ -418,12 +499,34 @@ while :; do
             hook_list
             exit 0
             ;;
+        -l|--splash)
+            shift
+            [[ -f $1 ]] || die "Invalid file -- must be a file"
+            _optsplash=$1
+            ;;
+        -i|--kernelimage)
+            shift
+             _optkernelimage=$1
+            ;;
+        -I|--uefistub)
+            shift
+             _optkernelimage=$1
+            ;;
         -M|--automods)
             _optshowautomods=1
+            ;;
+        -m|--microcode)
+            shift
+             _optmicrocode=$1
             ;;
         -P|--allpresets)
             _optpreset=("$_d_presets"/*.preset)
             [[ -e ${_optpreset[0]} ]] || die "No presets found in $_d_presets"
+            ;;
+        -R|--osrelease)
+            shift
+            [[ ! -f $1 ]] && die "Invalid file -- must be a file"
+            _optosrelease=$1
             ;;
         -t|--builddir)
             shift
@@ -554,6 +657,10 @@ elif [[ $_opttargetdir ]]; then
     msg "Build complete."
 else
     msg "Dry run complete, use -g IMAGE to generate a real image"
+fi
+
+if [[ $_optuefi && $_optgenimg ]]; then
+    build_uefi "$_optuefi" "$_optmicrocode" "$_optgenimg" "$_optcmdline" "$_optosrelease" "$_optkernelimage" "$_optsplash" "$_optuefistub"
 fi
 
 cleanup $(( !!_builderrors ))

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -22,8 +22,8 @@ _d_presets=mkinitcpio.d
 # options and runtime data
 _optmoduleroot= _optgenimg=
 _optcompress= _opttargetdir=
-_optosrelease="/usr/lib/os-release"
-_optuefi= _optmicrocode= _optcmdline= _optsplash= _optkernelimage= _optuefistub=
+_optosrelease="/etc/os-release"
+_optuefi= _optmicrocode=() _optcmdline= _optsplash= _optkernelimage= _optuefistub=
 _optshowautomods=0 _optsavetree=0 _optshowmods=0
 _optquiet=1 _optcolor=1
 _optskiphooks=() _optaddhooks=() _hooks=()  _optpreset=()
@@ -261,52 +261,73 @@ build_image() {
 }
 
 build_uefi(){
-    set -x
-    local out=$1 microcode=$2 initramfs=$3 cmdline=$4 osrelease=$5 splash=$6 kernelimg=$7 uefistub=$8 errmsg=
+    local out=$1 initramfs=$2 cmdline=$3 osrelease=$4 splash=$5 kernelimg=$6 uefistub=$7 microcode=(${@:7}) errmsg=
     OBJCOPYARGS=()
+
+    msg "Creating UEFI executable: %s" "$out"
 
     if [[ -z "$uefistub" ]]; then
         for stub in {/usr,}/lib/systemd/boot/efi/linux{x64,ia32}.efi.stub {/usr,}/lib/gummiboot/linux{x64,ia32}.efi.stub; do
             if [[ -f "$stub" ]]; then
                 uefistub="$stub"
+                msg2 "Using UEFI stub: %s" "$uefistub"
+                break
+            fi
+        done
+    elif [[ ! -f "$uefisub" ]]; then
+        error "UEFI stub '%s' not found" "$uefistub"
+        return 1
+    fi
+
+    if [[ -z "$kernelimg" ]]; then
+        for img in "/lib/modules/$KERNELVERSION/vmlinuz" "/boot/vmlinuz-$KERNELVERSION" "/boot/vmlinuz-linux"; do
+            if [[ -f "$img" ]]; then
+                kernelimg="$img"
+                msg2 "Using kernel image: %s" "$kernelimg"
                 break
             fi
         done
     fi
-
-    if [[ -z "$kernelimg" ]]; then
-        for img in "/lib/modules/$KERNELIMAGE" "/boot/vmlinuz-$KERNELIMAGE" "/boot/vmlinuz-linuz"; do
-            if [[ -f "$img" ]]; then
-                KERNELIMAGE="$img"
-                break
-            fi
-        done
+    if [[ ! -f "$kernelimg" ]]; then
+        error "Kernel image '%s' not found" "$kernelimage"
+        return 1
     fi
 
     if [[ -z "$cmdline" ]]; then
         if [[ -f "/etc/kernel/cmdline" ]]; then
             cmdline="/etc/kernel/cmdline"
+        elif [[ -f "/usr/lib/kernel/cmdline" ]]; then
+            cmdline="/usr/lib/kernel/cmdline"
         else
             cmdline="/proc/cmdline"
         fi
+        msg2 "Using cmdline file %s" "$cmdline"
+    fi
+    if [[ ! -f "$cmdline" ]]; then
+        error "Kernel cmdline file '%s' not found" "$cmdline"
+        return 1
+    fi
+
+    if [[ -z "$initramfs" ]]; then
+        error "Initramfs '%s' not found" "$initramfs"
+        return 1
     fi
 
     if [[ -n "$splash" ]]; then
-        OBJCOPYARGS+=("--add-section .splash=$splash --change-section-vma .splash=0x40000")
+        OBJCOPYARGS+=(--add-section .splash="$splash" --change-section-vma .splash=0x40000)
     fi
-    msg "Creating EFI image: %s" "$out"
     objcopy \
         --add-section .osrel="$osrelease" --change-section-vma .osrel=0x20000 \
         --add-section .cmdline="$cmdline" --change-section-vma .cmdline=0x30000 \
         --add-section .linux="$kernelimg" --change-section-vma .linux=0x2000000 \
-        --add-section .initrd=<(cat "$microcode" "$initramfs" ) --change-section-vma .initrd=0x3000000 \
+        --add-section .initrd=<(cat ${microcode[@]} "$initramfs") --change-section-vma .initrd=0x3000000 \
         ${OBJCOPYARGS[@]} "$uefistub" "$out"
 
     status=$?
     if (( $status )) ; then
-        error "EFI image generation FAILED"
+        error "UEFI executable generation FAILED"
     else
-        msg "EFI image generation successful"
+        msg "UEFI executable generation successful"
     fi
 }
 
@@ -371,11 +392,12 @@ process_preset() (
             preset_cmd+=(-U "${!preset_efi_image:-$ALL_efi_image}")
         fi
 
-        preset_microcode=${p}_microcode
+        preset_microcode=${p}_microcode[@]
         if [[ ${!preset_microcode:-$ALL_microcode} ]]; then
-            preset_cmd+=(-m "${!preset_microcode:-$ALL_microcode}")
+            for mc in "${!preset_microcode:-${ALL_microcode[@]}}"; do
+                preset_cmd+=(-m "$mc")
+            done
         fi
-
         msg2 "${preset_cmd[*]}"
         MKINITCPIO_PROCESS_PRESET=1 "$0" "${preset_cmd[@]}"
         (( $? )) && ret=1
@@ -414,7 +436,7 @@ preload_builtin_modules() {
 trap 'cleanup 130' INT
 trap 'cleanup 143' TERM
 
-_opt_short='A:c:D:g:H:hk:I:i:nLl:Mm:Pp:r:S:sd:t:U:Vvz:'
+_opt_short='A:C:c:D:g:H:hk:I:i:nLl:Mm:Pp:R:r:S:sd:t:U:Vvz:'
 _opt_long=('add:' 'addhooks:' 'config:' 'generate:' 'hookdir': 'hookhelp:' 'help'
           'kernel:' 'listhooks' 'automods' 'moduleroot:' 'nocolor' 'allpresets'
           'preset:' 'skiphooks:' 'save' 'generatedir:' 'builddir:' 'version' 'verbose' 'compress:'
@@ -517,7 +539,7 @@ while :; do
             ;;
         -m|--microcode)
             shift
-             _optmicrocode=$1
+            _optmicrocode+=($1)
             ;;
         -P|--allpresets)
             _optpreset=("$_d_presets"/*.preset)
@@ -660,7 +682,7 @@ else
 fi
 
 if [[ $_optuefi && $_optgenimg ]]; then
-    build_uefi "$_optuefi" "$_optmicrocode" "$_optgenimg" "$_optcmdline" "$_optosrelease" "$_optkernelimage" "$_optsplash" "$_optuefistub"
+    build_uefi "$_optuefi" "$_optgenimg" "$_optcmdline" "$_optosrelease" "$_optsplash" "$_optkernelimage" "$_optuefistub" "${_optmicrocode[@]}"
 fi
 
 cleanup $(( !!_builderrors ))

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -601,6 +601,14 @@ if [[ -n $_d_flag_hooks && -n $_d_flag_install ]]; then
     _d_install=${_d_flag_install%:}
 fi
 
+
+# If we specified --uefi but no -g we want to create a temporary initramfs which will be used with the efi executable.
+if [[ $_optuefi && $_optgenimg == "" ]]; then
+    tmpfile=$(mktemp -t mkinitcpio.XXXXXX)
+    trap "rm $tmpfile" EXIT
+    _optgenimg="$tmpfile"
+fi
+
 # insist that /proc and /dev be mounted (important for chroots)
 # NOTE: avoid using mountpoint for this -- look for the paths that we actually
 # use in mkinitcpio. Avoids issues like FS#26344.

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -267,7 +267,7 @@ build_uefi(){
     msg "Creating UEFI executable: %s" "$out"
 
     if [[ -z "$uefistub" ]]; then
-        for stub in {/usr,}/lib/systemd/boot/efi/linux{x64,ia32}.efi.stub {/usr,}/lib/gummiboot/linux{x64,ia32}.efi.stub; do
+        for stub in {/usr,}/lib/{systemd/boot/efi,gummiboot}/linux{x64,ia32}.efi.stub; do
             if [[ -f "$stub" ]]; then
                 uefistub="$stub"
                 msg2 "Using UEFI stub: %s" "$uefistub"
@@ -299,7 +299,9 @@ build_uefi(){
         elif [[ -f "/usr/lib/kernel/cmdline" ]]; then
             cmdline="/usr/lib/kernel/cmdline"
         else
+            warning "Note: /etc/kernel/cmdline does not exist and --cmdline is unset!"
             cmdline="/proc/cmdline"
+            warning "Reusing current kernel cmdline from $cmdline"
         fi
         msg2 "Using cmdline file %s" "$cmdline"
     fi

--- a/mkinitcpio.d/example.preset
+++ b/mkinitcpio.d/example.preset
@@ -18,11 +18,11 @@ ALL_microcode=(/boot/*-ucode.img)
 #default_kver="3.0-ARCH"
 #default_config="/etc/mkinitcpio.conf"
 default_image="/tmp/initramfs-linux.img"
-default_efi_image="/efi/EFI/Linux/linux.efi"
+default_efi_image="/efi/EFI/Linux/arch-linux.efi"
 default_options=""
 
 #fallback_kver="3.0-ARCH"
 #fallback_config="/etc/mkinitcpio.conf"
 fallback_image="/tmp/initramfs-linux-fallback.img"
-fallback_efi_image="/efi/EFI/Linux/linux-fallback.efi"
+fallback_efi_image="/efi/EFI/Linux/arch-linux-fallback.efi"
 fallback_options="-S autodetect"

--- a/mkinitcpio.d/example.preset
+++ b/mkinitcpio.d/example.preset
@@ -8,7 +8,7 @@ PRESETS=('default' 'fallback')
 # as the path to an kernel image.
 ALL_kver='/boot/vmlinuz-linux'
 ALL_config='/etc/mkinitcpio.conf'
-ALL_microcode="/boot/intel-ucode.img"
+ALL_microcode=(/boot/*-ucode.img)
 
 # presetname_kver    - the kernel version (omit if ALL_kver should be used)
 # presetname_config  - the configuration file (omit if ALL_config should be used)

--- a/mkinitcpio.d/example.preset
+++ b/mkinitcpio.d/example.preset
@@ -8,6 +8,7 @@ PRESETS=('default' 'fallback')
 # as the path to an kernel image.
 ALL_kver='/boot/vmlinuz-linux'
 ALL_config='/etc/mkinitcpio.conf'
+ALL_microcode="/boot/intel-ucode.img"
 
 # presetname_kver    - the kernel version (omit if ALL_kver should be used)
 # presetname_config  - the configuration file (omit if ALL_config should be used)
@@ -17,9 +18,11 @@ ALL_config='/etc/mkinitcpio.conf'
 #default_kver="3.0-ARCH"
 #default_config="/etc/mkinitcpio.conf"
 default_image="/tmp/initramfs-linux.img"
+default_efi_image="/efi/EFI/Linux/linux.efi"
 default_options=""
 
 #fallback_kver="3.0-ARCH"
 #fallback_config="/etc/mkinitcpio.conf"
 fallback_image="/tmp/initramfs-linux-fallback.img"
+fallback_efi_image="/efi/EFI/Linux/linux-fallback.efi"
 fallback_options="-S autodetect"


### PR DESCRIPTION
Missing stuff for this pull-request.

- [ ] Do we want a new section in the manpages?
- [ ] Is the flags okay enough?
- [x] Testing

---

Implement UEFI executable generation in mkinitcpio by utilizing UEFI
stubs provided by systemd/gummiboot.

This allows us to create a unified boot image we can boot from UEFI
with. These are practical for secure boot as we can sign initramfs,
kernel cmdline and the kernel all at once. By utilizing the
BOOT_LOADER_SPECIFICATION we can also drop new images into the correct
patch and have systemd-boot/gummiboot pick up the images.

The code does several things and does a fair amount of guessing to
figure out all the inputs needed.

We use `/etc/kernel/cmdline` to localize the kernel cmdline options we
want for the image. This is inherited from the `kernel-install` hook
system which might double as some form of standard.

We also do a dance to get the correct kernel image. We do a lookup into
/lib/modules and /boot for both versioned and unversioned kernels
(mainly Arch Linux).

There is an attempt to support both 32bit and 64bit lookup paths for the
stub images, but only 64bit is tested.

Gummiboot is also not tested.

https://www.freedesktop.org/software/systemd/man/kernel-install.html

https://systemd.io/BOOT_LOADER_SPECIFICATION/#type-2-efi-unified-kernel-images

Signed-off-by: Morten Linderud <morten@linderud.pw>