### PR TITLE
functions: move add_udev_rule() from systemd hook

### DIFF
--- a/functions
+++ b/functions
@@ -625,6 +625,46 @@ add_binary() {
     return 0
 }
 
+add_udev_rule() {
+    # Add an udev rules file to the initcpio image. Dependencies on binaries
+    # will be discovered and added.
+    #   $1: path to rules file (or name of rules file)
+
+    local rules="$1" rule= key= value= binary=
+
+    if [[ ${rules:0:1} != '/' ]]; then
+        rules=$(PATH=/usr/lib/udev/rules.d:/lib/udev/rules.d type -P "$rules")
+    fi
+    if [[ -z $rules ]]; then
+        # complain about not found rules
+        return 1
+    fi
+
+    add_file "$rules" /usr/lib/udev/rules.d/"${rules##*/}"
+
+    while IFS=, read -ra rule; do
+        # skip empty lines, comments
+        [[ -z $rule || $rule = @(+([[:space:]])|#*) ]] && continue
+
+        for pair in "${rule[@]}"; do
+            IFS=' =' read -r key value <<< "$pair"
+            case $key in
+                RUN@({program}|+)|IMPORT{program}|ENV{REMOVE_CMD})
+                    # strip quotes
+                    binary=${value//[\"\']/}
+                    # just take the first word as the binary name
+                    binary=${binary%% *}
+                    [[ ${binary:0:1} == '$' ]] && continue
+                    if [[ ${binary:0:1} != '/' ]]; then
+                        binary=$(PATH=/usr/lib/udev:/lib/udev type -P "$binary")
+                    fi
+                    add_binary "$binary"
+                    ;;
+            esac
+        done
+    done <"$rules"
+}
+
 parse_config() {
     # parse key global variables set by the config file.
 


### PR DESCRIPTION
This function can be used for setups with systemd in initramfs (hook
`systemd`) or without (hook `udev`). To avoid code duplication move
the code here.