### PR TITLE
mkinitcpio: fixed missing _opt_long

### DIFF
--- a/mkinitcpio
+++ b/mkinitcpio
@@ -412,7 +412,7 @@ process_preset() (
         preset_microcode=${p}_microcode[@]
         if [[ ${!preset_microcode:-$ALL_microcode} ]]; then
             for mc in "${!preset_microcode:-${ALL_microcode[@]}}"; do
-                preset_cmd+=(-m "$mc")
+                preset_cmd+=(--microcode "$mc")
             done
         fi
         msg2 "${preset_cmd[*]}"
@@ -457,7 +457,7 @@ _opt_short='A:c:D:g:H:hk:nLMPp:r:S:sd:t:U:Vvz:'
 _opt_long=('add:' 'addhooks:' 'config:' 'generate:' 'hookdir': 'hookhelp:' 'help'
           'kernel:' 'listhooks' 'automods' 'moduleroot:' 'nocolor' 'allpresets'
           'preset:' 'skiphooks:' 'save' 'generatedir:' 'builddir:' 'version' 'verbose' 'compress:'
-          'uefi:' 'microcode:' 'splash:' 'kernelimage:' 'uefistub:')
+          'uefi:' 'microcode:' 'splash:' 'kernelimage:' 'uefistub:' 'cmdline:' 'osrelease:')
 
 parseopts "$_opt_short" "${_opt_long[@]}" -- "$@" || exit 1
 set -- "${OPTRET[@]}"


### PR DESCRIPTION
The short opts where the only one tested, seems like a few of the long
opts was missing from the array.

Signed-off-by: Morten Linderud <morten@linderud.pw>