### PR TITLE
functions: add support for compressed firmware

### DIFF
--- a/functions
+++ b/functions
@@ -343,7 +343,10 @@ add_firmware() {
 
     for fw; do
         for fwpath in "${_d_firmware[@]}"; do
-            if [[ -f $fwpath/$fw ]]; then
+            if [[ -f $fwpath/$fw.xz ]]; then
+                add_file "$fwpath/$fw.xz" "$fwpath/$fw.xz" 644 && r=0
+                break
+            elif [[ -f $fwpath/$fw ]]; then
                 add_file "$fwpath/$fw" "$fwpath/$fw" 644 && r=0
                 break
             fi


### PR DESCRIPTION
Naive implementation for compressed firmware-support.

Kernel versions >= 5.3 [1] are able to load xz-compressed firmware images. XZ is the only  algorithm that is supported by the kernel and since then there was no notable work done to add more.

Distributions might ship a mix of compressed and uncompressed firmware images and there is no way to know in advance whether images are compressed or not, so we have to test for one case and then fall back to the other for every single image. Most systems will require only a modest amount of firmware in the initramfs, even if the first case falls through for all images it won't hurt performance much.

This doesn't account for kernels that don't enable CONFIG_FW_LOADER_COMPRESS.


[1] http://lkml.iu.edu/hypermail/linux/kernel/1907.1/04265.html