### PR TITLE
Warn, if the preset file does not contain any presets

### DIFF
--- a/mkinitcpio
+++ b/mkinitcpio
@@ -364,7 +364,7 @@ process_preset() (
 
     . "$preset" || die "Failed to load preset: \`%s'" "$preset"
 
-    (( ! ${#PRESETS[@]} )) && warning "Preset file \`%s' does not contain any presets." "$preset"
+    (( ! ${#PRESETS[@]} )) && warning "Preset file \`%s' is empty or does not contain any presets." "$preset"
 
     # Use -m and -v options specified earlier
     (( _optquiet )) || preset_mkopts+=(-v)

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -364,6 +364,8 @@ process_preset() (
 
     . "$preset" || die "Failed to load preset: \`%s'" "$preset"
 
+    (( ! ${#PRESETS[@]} )) && warning "Preset file \`%s' does not contain any presets." "$preset"
+
     # Use -m and -v options specified earlier
     (( _optquiet )) || preset_mkopts+=(-v)
     (( _optcolor )) || preset_mkopts+=(-n)


### PR DESCRIPTION
I just had a "fun" time recovering from a sysupdate-gone-wrong situation in which some files were corrupted and all initramfs files were gone. 
While trying to rescue the system, I re-ran mkinitcpio a couple of times but it never recreated the missing initramfs. Took me quite a while to figure out that the preset file (`/etc/mkinitcpio.d/linux.preset` in this case), was among the corrupted ones.
It was present and readable, but with a size of 0 bytes rather deserted...
mkinitcpio only checks that sourcing the preset file did not return any error, which makes perfect sense (from help):
```
    Exit Status:
    Returns the status of the last command executed in FILENAME; fails if
    FILENAME cannot be read.
```

Long story short, this adds a warning if the `PRESET` variable is empty after the "source" line.

Printing a warning is chosen over printing an error / exit with failure in order not to break (existing) scripts or use cases, in which multiple preset files shall be processed, of which one might be empty (intentionally?!).