### PR TITLE
fsck root device: respect provided rootfstype

### DIFF
--- a/functions
+++ b/functions
@@ -655,7 +655,8 @@ parse_config() {
             'EARLYHOOKS' "${_runhooks['early']# }" \
             'HOOKS' "${_runhooks['hooks']# }" \
             'LATEHOOKS' "${_runhooks['late']# }" \
-            'CLEANUPHOOKS' "${_runhooks['cleanup']% }"
+            'CLEANUPHOOKS' "${_runhooks['cleanup']% }" \
+            'DEFAULTROOTFSTYPE' "$_autodetect_rootfstype"
     } >"$BUILDROOT/config"
 }
 

--- a/hooks/usr
+++ b/hooks/usr
@@ -1,7 +1,7 @@
 #!/usr/bin/ash
 
 run_latehook() {
-    local usr_source mountopts passno realtab=/new_root/etc/fstab
+    local usr_source mountopts passno fstype realtab=/new_root/etc/fstab
 
     if [ -f "$realtab" ]; then
         if usr_source=$(findmnt -snero source --tab-file="$realtab" -T /usr); then
@@ -11,7 +11,8 @@ run_latehook() {
             # older versions which do not support this column, always fsck.
             passno=$(findmnt -snero passno --tab-file="$realtab" -T /usr 2>/dev/null)
             if [ -z "$passno" ] || [ "$passno" -gt 0 ]; then
-                fsck_device "$usr_source"
+                fstype=$(findmnt -snero fstype --tab-file="$realtab" -T /usr)
+                fsck_device "$usr_source" "$fstype"
             fi
             msg ":: mounting '$usr_source' on /usr"
             mount "$usr_source" /new_root/usr -o "$mountopts"

--- a/init_functions
+++ b/init_functions
@@ -261,7 +261,13 @@ fsck_device() {
 }
 
 fsck_root() {
-    fsck_device "$root" "$rootfstype"
+    if [ -n "$rootfstype" ]; then
+        fsck_device "$root" "$rootfstype"
+    elif [ -n "$DEFAULTROOTFSTYPE" ]; then
+        fsck_device "$root" "$DEFAULTROOTFSTYPE"
+    else
+        err "fsck on '$root' is skipped. No filesystem type is provided"
+    fi
     fsckret=$?
 
     if [ -n "$fsckret" ] && [ "$fsckret" -ne 255 ]; then

--- a/init_functions
+++ b/init_functions
@@ -257,11 +257,11 @@ fsck_device() {
     fi
 
     msg ":: performing fsck on '$1'"
-    fsck -Ta -C"$FSCK_FD" "$1" -- ${forcefsck+-f}
+    fsck -Ta -C"$FSCK_FD" ${2:+-t $2} "$1" -- ${forcefsck+-f}
 }
 
 fsck_root() {
-    fsck_device "$root"
+    fsck_device "$root" "$rootfstype"
     fsckret=$?
 
     if [ -n "$fsckret" ] && [ "$fsckret" -ne 255 ]; then

--- a/init_functions
+++ b/init_functions
@@ -261,10 +261,14 @@ fsck_device() {
 }
 
 fsck_root() {
+    local fstype
+
     if [ -n "$rootfstype" ]; then
         fsck_device "$root" "$rootfstype"
     elif [ -n "$DEFAULTROOTFSTYPE" ]; then
         fsck_device "$root" "$DEFAULTROOTFSTYPE"
+    elif fstype=$(blkid -o value -s TYPE "$1") && [ -n "$fstype" ]; then
+        fsck_device "$root" "$fstype"
     else
         err "fsck on '$root' is skipped. No filesystem type is provided"
     fi

--- a/init_functions
+++ b/init_functions
@@ -267,7 +267,7 @@ fsck_root() {
         fsck_device "$root" "$rootfstype"
     elif [ -n "$DEFAULTROOTFSTYPE" ]; then
         fsck_device "$root" "$DEFAULTROOTFSTYPE"
-    elif fstype=$(blkid -o value -s TYPE "$1") && [ -n "$fstype" ]; then
+    elif fstype=$(blkid -o value -s TYPE "$root") && [ -n "$fstype" ]; then
         fsck_device "$root" "$fstype"
     else
         err "fsck on '$root' is skipped. No filesystem type is provided"

--- a/install/autodetect
+++ b/install/autodetect
@@ -32,6 +32,7 @@ build() {
     # detect filesystem for root
     if rootfstype=$(findmnt -uno fstype -T '/'); then
         add_if_avail "$rootfstype"
+        _autodetect_rootfstype="$rootfstype"
     else
         error "failed to detect root filesystem"
         fs_autodetect_failed=1

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -20,6 +20,7 @@ _d_firmware=({/usr,}/lib/firmware/updates {/usr,}/lib/firmware)
 _d_presets=mkinitcpio.d
 
 # options and runtime data
+_autodetect_rootfstype=
 _optmoduleroot= _optgenimg=
 _optcompress= _opttargetdir=
 _optosrelease=


### PR DESCRIPTION
By default, `fsck` determines filesystem type with a lookup of `/etc/fstab`. As for now it's empty in initramfs. So it defaults to ext2. That could (and actually do) damage the filesystem if it's not of an ext-family. The `-a` option is propagated to fsck.ext2 and it make it worse. 
The solution is `fsck -t` option.  It will run the correct `fsck.$rootfstype` and not making harm with wrong one.