### PR TITLE
functions: allow tailing `+` for custom kernel build upon git trees

### DIFF
--- a/functions
+++ b/functions
@@ -158,7 +158,7 @@ kver_generic() {
     # https://elixir.bootlin.com/linux/v5.7.2/source/init/version.c#L46
     local kver=
 
-    read _ _ kver _ < <(grep -m1 -aoE 'Linux version .(\.[-[:alnum:]]+)+' "$1")
+    read _ _ kver _ < <(grep -m1 -aoE 'Linux version .(\.[-[:alnum:]+]+)+' "$1")
 
     printf '%s' "$kver"
 }


### PR DESCRIPTION
For kernels build upon git trees, any non-tag commit will append a '+'
char to kernel version.

This means the current fallback method will cut off the tailing '+' and
cause mkinitcpio failure for suck cases.

Signed-off-by: Qu Wenruo <wqu@suse.com>