### PR TITLE
mkinitcpio: add VERSION_ID to EFISTUB

### DIFF
--- a/mkinitcpio
+++ b/mkinitcpio
@@ -341,7 +341,7 @@ build_uefi(){
     done
 
     objcopy \
-        --add-section .osrel="$osrelease" --change-section-vma .osrel=0x20000 \
+        --add-section .osrel=<(cat "$osrelease" && echo "VERSION_ID=$KERNELVERSION") --change-section-vma .osrel=0x20000 \
         --add-section .cmdline=<(grep '^[^#]' "$cmdline" | tr -s '\n' ' ') --change-section-vma .cmdline=0x30000 \
         --add-section .linux="$kernelimg" --change-section-vma .linux=0x2000000 \
         --add-section .initrd=<(cat ${microcode[@]} "$initramfs") --change-section-vma .initrd=0x3000000 \


### PR DESCRIPTION
This patch adds VERSION_ID to the built images. This helps distinguish
between several kernel versions instead of having it fallback to showing
file names. The sd-boot menu shows the new entires with the given kernel
ID:

Old menu:
    * Arch Linux (arch-systemd.efi)
    * Arch Linux (test-efi.efi)

New menu:
    * Arch Linux (rolling)
    * Arch Linux (5.15.5-arch1-1)

Signed-off-by: Morten Linderud <morten@linderud.pw>