### PR TITLE
fix reproducibility, in case of /var/cache directory exists and is included in initramfs

### DIFF
--- a/mkinitcpio
+++ b/mkinitcpio
@@ -709,6 +709,8 @@ trap -- ERR
 
 # this is simply a nice-to-have -- it doesn't matter if it fails.
 ldconfig -r "$BUILDROOT" &>/dev/null
+# remove /var/cache/ldconfig/aux-cache for reproducability
+rm -f -- "$BUILDROOT/var/cache/ldconfig/aux-cache"
 
 # Set umask to create initramfs images and EFI images as 600
 umask 077


### PR DESCRIPTION
4th:
Remove not needed and not reproducable cache file
https://bugs.archlinux.org/task/73817