### PR TITLE
install/kms: move archiso_kms from mkinitcpio-archiso

### DIFF
--- a/install/kms
+++ b/install/kms
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+build() {
+    map add_checked_modules '/drivers/char/agp/' '/drivers/gpu/drm/'
+}
+
+help() {
+    cat <<HELPEOF
+Adds KMS drivers to the initramfs image. To minimize the modules in the image,
+add the autodetect hook too.
+HELPEOF
+}


### PR DESCRIPTION
This hook adds GPU drivers (`/drivers/char/agp/` and `/drivers/gpu/drm/`) to the initramfs for [early KMS](https://wiki.archlinux.org/title/Kernel_mode_setting#Early_KMS_start).

Copy of https://gitlab.archlinux.org/mkinitcpio/mkinitcpio-archiso/-/blob/23b9cd42417765cbd70e8cd26db2c699ef3cf01f/install/archiso_kms without the `SPDX-License-Identifier` line.
Fixes https://github.com/archlinux/mkinitcpio/issues/94.

```
Signed-off-by: nl6720 <nl6720@gmail.com>
```


@brain0, @djgera, @dvzrv, please comment with your `Signed-off-by` lines if you agree with this change and relicensing of the file.