### PR TITLE
Preserve kernel structure, remove awk hack on install_modules

### DIFF
--- a/functions
+++ b/functions
@@ -855,19 +855,18 @@ install_modules() {
         return 0
     fi
 
-    cp "$@" "$moduledest/kernel"
-
-    # unzip modules prior to recompression
     for m in "$@"; do
+        install -D -m644 "$m" "$BUILDROOT/$m"
+        # unzip modules prior to recompression
         case $m in
             *.xz)
-                xz_comp+=("$moduledest/kernel/${m##*/}")
+                xz_comp+=("$BUILDROOT/$m")
                 ;;
             *.gz)
-                gz_comp+=("$moduledest/kernel/${m##*/}")
+                gz_comp+=("$BUILDROOT/$m")
                 ;;
             *.zst)
-                zst_comp+=("$moduledest/kernel/${m##*/}")
+                zst_comp+=("$BUILDROOT/$m")
                 ;;
         esac
     done
@@ -877,14 +876,7 @@ install_modules() {
 
     msg "Generating module dependencies"
     install -m644 -t "$moduledest" "$_d_kmoduledir"/modules.builtin
-
-    # we install all modules into kernel/, making the .order file incorrect for
-    # the module tree. munge it, so that we have an accurate index. This avoids
-    # some rare and subtle issues with module loading choices when an alias
-    # resolves to multiple modules, only one of which can claim a device.
-    awk -F'/' '{ print "kernel/" $NF }' \
-        "$_d_kmoduledir"/modules.order >"$moduledest/modules.order"
-
+    install -m644 -t "$moduledest" "$_d_kmoduledir"/modules.order
     depmod -b "$BUILDROOT" "$KERNELVERSION"
 
     # remove all non-binary module.* files (except devname for on-demand module loading)


### PR DESCRIPTION
- messing around with modules is not really needed 
- modules.order does not include aliases or double entries
- if a module alias should conflict, it's already a corner case which should be solved in MODULES='' array or by the other kernel methods documented to stop loading a certain conflicting module. (module blacklisting).