### PR TITLE
Variable typo correction

### DIFF
--- a/mkinitcpio
+++ b/mkinitcpio
@@ -277,7 +277,7 @@ build_uefi(){
                 break
             fi
         done
-    elif [[ ! -f "$uefisub" ]]; then
+    elif [[ ! -f "$uefistub" ]]; then
         error "UEFI stub '%s' not found" "$uefistub"
         return 1
     fi

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -292,7 +292,7 @@ build_uefi(){
         done
     fi
     if [[ ! -f "$kernelimg" ]]; then
-        error "Kernel image '%s' not found" "$kernelimage"
+        error "Kernel image '%s' not found" "$kernelimg"
         return 1
     fi
 


### PR DESCRIPTION
I corrected a typo in a $uefistub variable used in the build_uefi function.

Edit: corrected another typo.