### PR TITLE
fixed empty uefistub detection

### DIFF
--- a/mkinitcpio
+++ b/mkinitcpio
@@ -278,7 +278,7 @@ build_uefi(){
             fi
         done
     fi
-    if [[ ! -f "$uefisub" ]]; then
+    if [[ ! -f "$uefistub" ]]; then
         error "UEFI stub '%s' not found" "$uefistub"
         return 1
     fi

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -277,7 +277,8 @@ build_uefi(){
                 break
             fi
         done
-    elif [[ ! -f "$uefisub" ]]; then
+    fi
+    if [[ ! -f "$uefisub" ]]; then
         error "UEFI stub '%s' not found" "$uefistub"
         return 1
     fi


### PR DESCRIPTION
In the current state if the uefistub arg is empty and the loop fails to find a stub it will still continue execution as the check for an empty uefistub is done in the elif.

This leads to nondescript error messages like:
```
objcopy: '': No such file
objcopy: --change-section-vma .splash=0x0000000000040000 never used
objcopy: --change-section-vma .initrd=0x0000000003000000 never used
objcopy: --change-section-vma .linux=0x0000000002000000 never used
objcopy: --change-section-vma .cmdline=0x0000000000030000 never used
objcopy: --change-section-vma .osrel=0x0000000000020000 never used
==> ERROR: UEFI executable generation FAILED
```
on systems where systemd-stub is not installed