### PR TITLE
Expand @() as it fails when extglob is not set

### DIFF
--- a/functions
+++ b/functions
@@ -679,7 +679,7 @@ add_udev_rule() {
         for pair in "${rule[@]}"; do
             IFS=' =' read -r key value <<< "$pair"
             case $key in
-                RUN@({program}|+)|IMPORT{program}|ENV{REMOVE_CMD})
+                RUN{program}|RUN+|IMPORT{program}|ENV{REMOVE_CMD})
                     # strip quotes
                     binary=${value//[\"\']/}
                     # just take the first word as the binary name


### PR DESCRIPTION
Currently, as per #102,  sourcing /usr/lib/initcpio/functions when `extglob` is not set in Bash produces an error. This PR expands the case pattern so `@()` extended pattern is not used.

The alternative would be to force `shopt -s extglob` at the top of the file, but that wouldn't respect user's choice for this option.