### PR TITLE
autodetect does not work for overlay fs, set autodetect to failed

### DIFF
--- a/install/autodetect
+++ b/install/autodetect
@@ -31,7 +31,12 @@ build() {
 
     # detect filesystem for root
     if rootfstype=$(findmnt -uno fstype -T '/'); then
-        add_if_avail "$rootfstype"
+        if [[ "${rootfstype}" == "overlay" ]]; then
+            warning "cannot detect type of overlayfs root filesystem"
+            fs_autodetect_failed=1
+        else
+            add_if_avail "$rootfstype"
+        fi
     else
         error "failed to detect root filesystem"
         fs_autodetect_failed=1


### PR DESCRIPTION
It is possible to get the upper/lower directories for overlay fs:
```
findmnt -n '/' | sed -e 's/ /\n/g' -e 's/,/\n/g' | sed -e '/^\(lower\|upper\)dir=/!d'
```
Since the root was switched to the overlay mount point, these mountpoints usually don't exist. I don't know a solution to detect the filesystemtypes of these "old" mountpoints, so fallback to autodetect failed.
If there is a better solution, I am happy to adapt the PR.