### PR TITLE
Add signing for unified uefi binary

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -16,7 +16,8 @@ optdepends=('gzip: Use gzip compression for the initramfs image'
             'bzip2: Use bzip2 compression for the initramfs image'
             'lzop: Use lzo compression for the initramfs image'
             'lz4: Use lz4 compression for the initramfs image'
-            'mkinitcpio-nfs-utils: Support for root filesystem on NFS')
+            'mkinitcpio-nfs-utils: Support for root filesystem on NFS'
+            'sbsigntools: Support for signing EFI binaries')
 backup=(etc/mkinitcpio.conf)
 
 build() {

--- a/man/mkinitcpio.8.txt
+++ b/man/mkinitcpio.8.txt
@@ -139,6 +139,16 @@ Options for UEFI executable
 	Include a os-release file for the UEFI executable.
 	Default: '/etc/os-release' or '/usr/lib/os-release'.
 
+*--key* 'filename'::
+	Sign the uefi binary using this key.
+	(PEM-encoded RSA private key) Default: no.
+	Also requires --cert
+
+*--cert* 'filename'::
+	Sign the uefi binary using this certificate.
+	(x509 certificate) Default: no.
+	Also requires --key
+
 About Presets
 -------------
 A preset is a pre-defined definition on how to create an initial ramdisk.

--- a/mkinitcpio
+++ b/mkinitcpio
@@ -23,7 +23,7 @@ _d_presets=mkinitcpio.d
 _optmoduleroot= _optgenimg=
 _optcompress= _opttargetdir=
 _optosrelease=
-_optuefi= _optmicrocode=() _optcmdline= _optsplash= _optkernelimage= _optuefistub=
+_optuefi= _optmicrocode=() _optcmdline= _optsplash= _optkernelimage= _optuefistub= _optkey= _optcert=
 _optshowautomods=0 _optsavetree=0 _optshowmods=0
 _optquiet=1 _optcolor=1
 _optskiphooks=() _optaddhooks=() _hooks=()  _optpreset=()
@@ -74,6 +74,8 @@ usage: ${0##*/} [options]
    --splash <path>              Include bitmap splash
    --kernelimage <path>         Kernel image
    --uefistub <path>            Location of UEFI stub loader
+   --key <path>                 UEFI signing: key (PEM-encoded RSA private key)
+   --cert <path>                UEFI signing: certificate (x509 certificate)
 
 EOF
 }
@@ -355,6 +357,36 @@ build_uefi(){
     fi
 }
 
+sign_uefi(){
+    local out=$1 key=$2 cert=$3 errmsg=
+
+    msg "Signing UEFI executable: %s" "$out"
+
+    if [[ ! "$key" || ! "$cert" ]]; then
+        error "for signing the uefi binary both --key and --cert must be given"
+        return 1
+    fi
+
+    if [[ ! -f "$key" ]]; then
+        error "signing key file '%s' not found" "$key"
+        return 1
+    fi
+
+    if [[ ! -f "$cert" ]]; then
+        error "signing certificate '%s' not found" "$cert"
+        return 1
+    fi
+
+    sbsign --key "$key" --cert "$cert" --output "$out" "$out"
+
+    status=$?
+    if (( $status )) ; then
+        error "UEFI executable signing FAILED"
+    else
+        msg "UEFI executable signing successful"
+    fi
+}
+
 process_preset() (
     local preset=$1 preset_cli_options=$2 preset_image= preset_options=
     local -a preset_mkopts preset_cmd
@@ -417,6 +449,16 @@ process_preset() (
             preset_cmd+=(-U "${!preset_efi_image:-$ALL_efi_image}")
         fi
 
+        preset_efi_key=${p}_efi_key
+        if [[ ${!preset_efi_key:-$ALL_efi_key} ]]; then
+            preset_cmd+=(--key "${!preset_efi_key:-$ALL_efi_key}")
+        fi
+
+        preset_efi_cert=${p}_efi_cert
+        if [[ ${!preset_efi_cert:-$ALL_efi_cert} ]]; then
+            preset_cmd+=(--cert "${!preset_efi_cert:-$ALL_efi_cert}")
+        fi
+
         preset_microcode=${p}_microcode[@]
         if [[ ${!preset_microcode:-$ALL_microcode} ]]; then
             for mc in "${!preset_microcode:-${ALL_microcode[@]}}"; do
@@ -467,7 +509,7 @@ _opt_short='A:c:D:g:H:hk:nLMPp:r:S:sd:t:U:Vvz:'
 _opt_long=('add:' 'addhooks:' 'config:' 'generate:' 'hookdir': 'hookhelp:' 'help'
           'kernel:' 'listhooks' 'automods' 'moduleroot:' 'nocolor' 'allpresets'
           'preset:' 'skiphooks:' 'save' 'generatedir:' 'builddir:' 'version' 'verbose' 'compress:'
-          'uefi:' 'microcode:' 'splash:' 'kernelimage:' 'uefistub:' 'cmdline:' 'osrelease:')
+          'uefi:' 'microcode:' 'splash:' 'kernelimage:' 'uefistub:' 'cmdline:' 'osrelease:' 'cert:' 'key:')
 
 parseopts "$_opt_short" "${_opt_long[@]}" -- "$@" || exit 1
 set -- "${OPTRET[@]}"
@@ -560,6 +602,14 @@ while :; do
         --uefistub)
             shift
              _optkernelimage=$1
+            ;;
+        --key)
+            shift
+            _optkey=$1
+            ;;
+        --cert)
+            shift
+            _optcert=$1
             ;;
         -M|--automods)
             _optshowautomods=1
@@ -723,6 +773,9 @@ fi
 
 if [[ $_optuefi && $_optgenimg ]]; then
     build_uefi "$_optuefi" "$_optgenimg" "$_optcmdline" "$_optosrelease" "$_optsplash" "$_optkernelimage" "$_optuefistub" "${_optmicrocode[@]}"
+    if [[ $_optkey || $_optcert ]]; then
+        sign_uefi "$_optuefi" "$_optkey" "$_optcert"
+    fi
 fi
 
 cleanup $(( !!_builderrors ))

--- a/mkinitcpio.d/example.preset
+++ b/mkinitcpio.d/example.preset
@@ -20,9 +20,13 @@ ALL_microcode=(/boot/*-ucode.img)
 default_image="/tmp/initramfs-linux.img"
 default_efi_image="/efi/EFI/Linux/arch-linux.efi"
 default_options=""
+default_efi_key=""
+default_efi_cert=""
 
 #fallback_kver="3.0-ARCH"
 #fallback_config="/etc/mkinitcpio.conf"
 fallback_image="/tmp/initramfs-linux-fallback.img"
 fallback_efi_image="/efi/EFI/Linux/arch-linux-fallback.efi"
 fallback_options="-S autodetect"
+fallback_efi_key=""
+fallback_efi_cert=""

--- a/shell/bash-completion
+++ b/shell/bash-completion
@@ -59,12 +59,12 @@ _mkinitcpio() {
     opts=(-A --addhooks -c --config -D --hookdir -d --generatedir -g --generate -H --hookhelp -h --help -k --kernel
           -L --listhooks -M --automods -n --nocolor -P --allpresets -p --preset -r --moduleroot
           -S --skiphooks -s --save -t --builddir -V --version -v --verbose -z --compress
-          -U --cmdline --kernelimage --microcode --osrelease --splash --uefi --uefistub)
+          -U --cmdline --kernelimage --microcode --osrelease --splash --uefi --uefistubs --key --cert)
 
     _get_comp_words_by_ref cur prev
 
     case $prev in
-        -[cgU]|--cmdline|--config|--generate|--kernelimage|--microcode|--osrelease|--splash|--uefi|--uefistub)
+        -[cgU]|--cmdline|--config|--generate|--kernelimage|--microcode|--osrelease|--splash|--uefi|--uefistub|--key|--cert)
             _filedir ;;
         -D|--hookdir|-d|--generatedir|-r|--moduleroot|-t|--builddir)
             _filedir -d ;;

--- a/shell/zsh-completion
+++ b/shell/zsh-completion
@@ -66,6 +66,8 @@ case $service in
             '--osrelease[Include a os-release file for the UEFI executable]:path:_files' \
             '--splash[Bitmap splash image to include in UEFI executable]:path:_files' \
             '--uefistub[UEFI stub image used for UEFI executable generation]:path:_files' \
+            '--key[UEFI signing: key (PEM-encoded RSA private key)]:path:_files' \
+            '--cert[UEFI signing: certificate (x509 certificate)]:path:_files' \
         ;;
     *)
         return 1;


### PR DESCRIPTION
Hi - This patch adds an option to automatically sign the generated uefi binary for use with SecureBoot.
I've tested it for quiet a while now, but if there is a better solution, I am happy to adapt the PR.