### PR TITLE
Fix the warning about missing modules.builtin.modinfo

### DIFF
--- a/functions
+++ b/functions
@@ -876,7 +876,7 @@ install_modules() {
     (( ${#zst_comp[*]} )) && zstd -d --rm -q "${zst_comp[@]}"
 
     msg "Generating module dependencies"
-    install -m644 -t "$moduledest" "$_d_kmoduledir"/modules.builtin
+    install -m644 -t "$moduledest" "$_d_kmoduledir"/modules.{builtin,builtin.modinfo,order}
 
     # we install all modules into kernel/, making the .order file incorrect for
     # the module tree. munge it, so that we have an accurate index. This avoids


### PR DESCRIPTION
> depmod: WARNING: could not open modules.builtin.modinfo at /tmp/mkinitcpio.EftMSK/root/lib/modules/5.15.52-1-lts: No such file or directory

kmod wants modules.builtin.modinfo since v30 [1]

[1] https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/commit/?id=0246e06340df292b5dda4bc00e24cc9ae894e881