### PR TITLE
install/block: include spi modules

### DIFF
--- a/install/block
+++ b/install/block
@@ -20,6 +20,9 @@ build() {
 
     # mmc
     add_checked_modules '/(drivers/mmc|tifm_)'
+    
+    # spi
+    add_checked_modules '/drivers/spi/'
 
     # virtio
     add_checked_modules 'virtio'

--- a/install/block
+++ b/install/block
@@ -20,8 +20,8 @@ build() {
 
     # mmc
     add_checked_modules '/(drivers/mmc|tifm_)'
-    
-    # spi
+
+    # spi (mmc in spi mode)
     add_checked_modules '/drivers/spi/'
 
     # virtio


### PR DESCRIPTION
SPI is used to provide access to mmc devices on some development boards (for example, HiFive Unmatched). The board doesn't boot from SD card properly without them included.

The whole `drivers/spi` folder is 380KiB in size, uncompressed, it shouldn't be a lot to add :)