### PR TITLE
fsck.xfs needs xfs_repair for actual work (only with -f/forcefsck).

### DIFF
--- a/install/fsck
+++ b/install/fsck
@@ -10,6 +10,9 @@ build() {
             add_binary fsck.ext4
             add_symlink /usr/bin/fsck.ext2 fsck.ext4
             add_symlink /usr/bin/fsck.ext3 fsck.ext4
+        elif [[ $1 = xfs ]]; then
+            add_binary fsck.xfs
+            add_binary xfs_repair
         else
             add_binary "fsck.$1"
         fi
@@ -23,7 +26,7 @@ build() {
             add_fsck $usrfstype && (( ++added ))
         fi
     else
-        for fsck in /usr/bin/fsck.*; do
+        for fsck in /usr/bin/fsck.* /usr/bin/xfs_repair; do
             [[ -f $fsck ]] || continue
             add_binary "$fsck" && (( ++added ))
         done


### PR DESCRIPTION
`fsck.xfs` is a shell script that used to just "do nothing, succesfully", but since 5.15 it calls `xfs_repair` when invoked with -f, so we need it included with initcpio.