### PR TITLE
Update mkinitcpio.conf

### DIFF
--- a/mkinitcpio.conf
+++ b/mkinitcpio.conf
@@ -3,7 +3,7 @@
 # The following modules are loaded before any boot hooks are
 # run.  Advanced users may wish to specify all system modules
 # in this array.  For instance:
-#     MODULES=(piix ide_disk reiserfs)
+#     MODULES=(usbhid xhci_hcd)
 MODULES=()
 
 # BINARIES
@@ -29,27 +29,27 @@ FILES=()
 # 'filesystems' is _required_ unless you specify your fs modules in MODULES
 # Examples:
 ##   This setup specifies all modules in the MODULES setting above.
-##   No raid, lvm2, or encrypted root is needed.
+##   No RAID, lvm2, or encrypted root is needed.
 #    HOOKS=(base)
 #
 ##   This setup will autodetect all modules for your system and should
 ##   work as a sane default
-#    HOOKS=(base udev autodetect block filesystems)
+#    HOOKS=(base udev autodetect modconf block filesystems fsck)
 #
 ##   This setup will generate a 'full' image which supports most systems.
 ##   No autodetection is done.
-#    HOOKS=(base udev block filesystems)
+#    HOOKS=(base udev modconf block filesystems fsck)
 #
-##   This setup assembles a pata mdadm array with an encrypted root FS.
-##   Note: See 'mkinitcpio -H mdadm' for more information on raid devices.
-#    HOOKS=(base udev block mdadm encrypt filesystems)
+##   This setup assembles a mdadm array with an encrypted root file system.
+##   Note: See 'mkinitcpio -H mdadm_udev' for more information on RAID devices.
+#    HOOKS=(base udev keyboard keymap consolefont modconf block mdadm_udev encrypt filesystems fsck)
 #
-##   This setup loads an lvm2 volume group on a usb device.
-#    HOOKS=(base udev block lvm2 filesystems)
+##   This setup loads an lvm2 volume group.
+#    HOOKS=(base udev modconf block lvm2 filesystems fsck)
 #
 ##   NOTE: If you have /usr on a separate partition, you MUST include the
-#    usr, fsck and shutdown hooks.
-HOOKS=(base udev autodetect modconf block filesystems keyboard fsck)
+#    usr and fsck hooks.
+HOOKS=(base udev autodetect keyboard keymap consolefont modconf block filesystems fsck)
 
 # COMPRESSION
 # Use this to compress the initramfs image. By default, zstd compression

--- a/mkinitcpio.conf
+++ b/mkinitcpio.conf
@@ -49,7 +49,7 @@ FILES=()
 #
 ##   NOTE: If you have /usr on a separate partition, you MUST include the
 #    usr and fsck hooks.
-HOOKS=(base udev autodetect keyboard keymap consolefont modconf block filesystems fsck)
+HOOKS=(base udev autodetect kms keyboard keymap consolefont modconf block filesystems fsck)
 
 # COMPRESSION
 # Use this to compress the initramfs image. By default, zstd compression


### PR DESCRIPTION
* Use more commonly known modules for the `MODULES` array example.
* Add the `modconf` hook to all example lines.
* Add keyboard, `keymap` and `consolefont` hooks to the examples using encryption. Mostly based on https://wiki.archlinux.org/title/dm-crypt/System_configuration
* Replace `mdadm` hook with `mdadm_udev`. There were merged into one. Fixes https://bugs.archlinux.org/task/68495
* Do not mention the obsolete `shutdown` hook.
* Add `kms` to the default `HOOKS` array.