### PR TITLE
install/kms: add modules that may implement the privacy screen interface

### DIFF
--- a/install/kms
+++ b/install/kms
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
 build() {
+    # AGP and DRM modules for GPUs
     map add_checked_modules '/drivers/char/agp/' '/drivers/gpu/drm/'
+
+    # modules that may implement the privacy screen interface
+    add_checked_modules '/drivers/platform/.*(acpi|privacy|wmi)'
 }
 
 help() {
     cat <<HELPEOF
-Adds KMS drivers to the initramfs image. To minimize the modules in the image,
-add the autodetect hook too.
+Adds KMS and privacy screen drivers to the initramfs image. To minimize the
+modules in the image, add the autodetect hook too.
 HELPEOF
 }


### PR DESCRIPTION
https://lore.kernel.org/intel-gfx/20210421204804.589962-1-hdegoede%40redhat.com/ says that "privacy screen is actually controlled by some vendor specific ACPI/WMI interface which has a driver under drivers/platform/x86".

Since there's also `/drivers/platform/chrome/chromeos_privacy_screen`, check whole `/drivers/platform/` for modules with "acpi", "privacy" or "wmi" in their filename.

Fixes [FS#72964](https://bugs.archlinux.org/task/72964).