### PR TITLE
fsck: Don't add fsck binary for OverlayFS

### DIFF
--- a/install/fsck
+++ b/install/fsck
@@ -5,6 +5,7 @@ build() {
 
     add_fsck() {
         [[ $1 = tmpfs ]] && return
+        [[ $1 = overlay ]] && return
 
         if [[ $1 = ext[234] ]]; then
             add_binary fsck.ext4


### PR DESCRIPTION
When using OverlayFS on the root mount, the fsck hook will attempt to add the corresponding fsck binary, which doesn't exist.

      -> Running build hook: [fsck]
    ==> ERROR: file not found: `fsck.overlay'

My `mount` output on the installation where I encountered this error:

    none on / type overlay (rw,relatime,lowerdir=base/,upperdir=overlay/overlay-upper/,workdir=overlay/overlay-work/)