### PR TITLE
install/fsck: always use the add_fsck function to add fsck helpers

### DIFF
--- a/install/fsck
+++ b/install/fsck
@@ -4,19 +4,25 @@ build() {
     local fsck= added=0
 
     add_fsck() {
-        [[ $1 = tmpfs ]] && return
-        [[ $1 = overlay ]] && return
-
-        if [[ $1 = ext[234] ]]; then
+        case "$1" in
+        ext[234])
             add_binary fsck.ext4
             add_symlink /usr/bin/fsck.ext2 fsck.ext4
             add_symlink /usr/bin/fsck.ext3 fsck.ext4
-        elif [[ $1 = xfs ]]; then
+            [[ -e /etc/e2fsck.conf ]] && add_file /etc/e2fsck.conf
+            ;;
+        xfs)
             add_binary fsck.xfs
             add_binary xfs_repair
-        else
-            add_binary "fsck.$1"
-        fi
+            ;;
+        *)
+            if compgen -c "fsck.$1" &> /dev/null; then
+                add_binary "fsck.$1"
+            else
+                return 1
+            fi
+            ;;
+        esac
     }
 
     if (( ! fs_autodetect_failed )) && [[ $rootfstype$usrfstype ]]; then
@@ -27,9 +33,8 @@ build() {
             add_fsck $usrfstype && (( ++added ))
         fi
     else
-        for fsck in /usr/bin/fsck.* /usr/bin/xfs_repair; do
-            [[ -f $fsck ]] || continue
-            add_binary "$fsck" && (( ++added ))
+        for fsck in $(compgen -c fsck.); do
+            add_fsck "${fsck#fsck.}" && (( ++added ))
         done
     fi
 
@@ -39,10 +44,6 @@ build() {
     fi
 
     add_binary fsck
-    if [[ -e /etc/e2fsck.conf ]]; then
-        add_file /etc/e2fsck.conf
-    fi
-
 }
 
 help() {

--- a/install/fsck
+++ b/install/fsck
@@ -6,9 +6,10 @@ build() {
     add_fsck() {
         case "$1" in
         ext[234])
-            add_binary fsck.ext4
-            add_symlink /usr/bin/fsck.ext2 fsck.ext4
-            add_symlink /usr/bin/fsck.ext3 fsck.ext4
+            add_binary e2fsck
+            add_symlink /usr/bin/fsck.ext2 e2fsck
+            add_symlink /usr/bin/fsck.ext3 e2fsck
+            add_symlink /usr/bin/fsck.ext4 e2fsck
             [[ -e /etc/e2fsck.conf ]] && add_file /etc/e2fsck.conf
             ;;
         xfs)


### PR DESCRIPTION
Check if the fsck helper of a `/` or `/usr` file system exists before adding it. This way, nonexistent fsck helper names do not need to be hardcoded.

Add the `e2fsck` binary and symlink `fsck.ext2`, `fsck.ext3` and `fsck.ext4` to it.