### PR TITLE
Add support for building UEFI bundles on aarch64

### DIFF
--- a/mkinitcpio
+++ b/mkinitcpio
@@ -290,7 +290,7 @@ build_uefi(){
     msg "Creating UEFI executable: %s" "$out"
 
     if [[ -z "$uefistub" ]]; then
-        for stub in {/usr,}/lib/{systemd/boot/efi,gummiboot}/linux{x64,ia32}.efi.stub; do
+        for stub in {/usr,}/lib/{systemd/boot/efi,gummiboot}/linux{x64,ia32,aa64}.efi.stub; do
             if [[ -f "$stub" ]]; then
                 uefistub="$stub"
                 msg2 "Using UEFI stub: %s" "$uefistub"


### PR DESCRIPTION
Previously this would fail:

```
==> Creating UEFI executable: /boot/EFI/Linux/arch.efi
==> ERROR: UEFI stub '' not found
```

With this change, the bundle is built fine:

```
==> Image generation successful
==> Creating UEFI executable: /boot/EFI/Linux/arch.efi
  -> Using UEFI stub: /usr/lib/systemd/boot/efi/linuxaa64.efi.stub
  -> Using kernel image: /lib/modules/6.1.0-rc3-asahi-1-1-ARCH/vmlinuz
  -> Using cmdline file: /etc/kernel/cmdline
  -> Using os-release file: /etc/os-release
==> UEFI executable generation successful
```