### PR TITLE
install/block: include pci controller modules

### DIFF
--- a/install/block
+++ b/install/block
@@ -25,6 +25,9 @@ build() {
     # spi (mmc in spi mode)
     add_checked_modules '/drivers/spi/'
 
+    # pci controller
+    add_checked_modules '/drivers/pci/controller/'
+
     # virtio
     add_checked_modules 'virtio'
 


### PR DESCRIPTION
Fixes virtio-blk devices attached to PCI on QEMU (which is the case for libvirt), and possibly also hyperv.

Only 38K in size on x86_64, shouldn't be a problem to add :)