### PR TITLE
Fix typo in mkinitcpio switch case

### DIFF
--- a/mkinitcpio
+++ b/mkinitcpio
@@ -228,7 +228,7 @@ build_image() {
             ;;
         *)
             msg "Creating %s-compressed initcpio image: '%s'" "$compress" "$out"
-            ;;&
+            ;;
         xz)
             COMPRESSION_OPTIONS=('-T0' '--check=crc32' "${COMPRESSION_OPTIONS[@]}")
             ;;


### PR DESCRIPTION
Looks like there is a superfluous `&` after a `;;` delimiter, not sure what its side effect was...