### PR TITLE
Fix check if kernel command line parameter is given as an absolute path

### DIFF
--- a/mkinitcpio
+++ b/mkinitcpio
@@ -917,7 +917,7 @@ while :; do
             _optnocmdline=1
             ;;
         -k | --kernel)
-            if [[ "$KERNELVERSION" == /* ]]; then
+            if [[ "$2" == /* ]]; then
                 KERNELVERSION="$(check_path r "$1" "$2")" || exit
             else
                 KERNELVERSION="$2"


### PR DESCRIPTION
If I understand the code correctly I think this condition is supposed to check if the value given for the --kernel command line parameter is an absolute path.